### PR TITLE
feat : PROJ-103 : 감정 테이블 생성 및 등록 로직 구현

### DIFF
--- a/server/Spring/src/main/java/com/hanium/diarist/domain/emotion/controller/EmotionController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/emotion/controller/EmotionController.java
@@ -1,0 +1,28 @@
+package com.hanium.diarist.domain.emotion.controller;
+
+import com.hanium.diarist.domain.emotion.dto.CreateEmotionRequest;
+import com.hanium.diarist.domain.emotion.dto.CreateEmotionResponse;
+import com.hanium.diarist.domain.emotion.service.EmotionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/emotion")
+@RequiredArgsConstructor
+public class EmotionController {
+    private final EmotionService emotionService;
+
+    @PostMapping("/create")
+    public ResponseEntity<List<CreateEmotionResponse>> createEmotions(@RequestBody List<CreateEmotionRequest> createEmotionRequests) {
+        List<CreateEmotionResponse> emotions = emotionService.createEmotions(createEmotionRequests);
+        return new ResponseEntity<>(emotions, HttpStatus.CREATED);
+    }
+
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/emotion/domain/Emotion.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/emotion/domain/Emotion.java
@@ -1,0 +1,34 @@
+package com.hanium.diarist.domain.emotion.domain;
+
+import com.hanium.diarist.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Emotion extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long emotionId;
+
+    @Column(nullable = false)
+    private String emotionName;
+
+    @Column(nullable = false)
+    private String emotionPrompt;
+
+    private String emotionPicture;
+
+    private Emotion(String emotionName, String emotionPrompt, String emotionPicture) {
+        this.emotionName = emotionName;
+        this.emotionPrompt = emotionPrompt;
+        this.emotionPicture = emotionPicture;
+    }
+
+    public static Emotion create(String emotionName, String emotionPrompt, String emotionPicture) {
+        return new Emotion(emotionName, emotionPrompt, emotionPicture);
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/emotion/dto/CreateEmotionRequest.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/emotion/dto/CreateEmotionRequest.java
@@ -1,0 +1,21 @@
+package com.hanium.diarist.domain.emotion.dto;
+
+import com.hanium.diarist.domain.emotion.domain.Emotion;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateEmotionRequest {
+
+    private String emotionName;
+    private String emotionPrompt;
+    private String emotionPicture;
+
+    public Emotion toEmotionEntity() {// 감정 객체 만드는 메소드 호출
+        return Emotion.create(emotionName, emotionPrompt, emotionPicture);
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/emotion/dto/CreateEmotionResponse.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/emotion/dto/CreateEmotionResponse.java
@@ -1,0 +1,20 @@
+package com.hanium.diarist.domain.emotion.dto;
+
+import com.hanium.diarist.domain.emotion.domain.Emotion;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public class CreateEmotionResponse {
+    private final Long emotionId;
+    private final String emotionName;
+    private final String emotionPicture;
+
+    public static CreateEmotionResponse of(Emotion emotion) {
+        return new CreateEmotionResponse(emotion.getEmotionId(), emotion.getEmotionName(), emotion.getEmotionPicture());
+    }
+
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/emotion/repository/EmotionRepository.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/emotion/repository/EmotionRepository.java
@@ -1,0 +1,8 @@
+package com.hanium.diarist.domain.emotion.repository;
+
+import com.hanium.diarist.domain.emotion.domain.Emotion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmotionRepository extends JpaRepository<Emotion, Long>{
+
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/emotion/service/EmotionService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/emotion/service/EmotionService.java
@@ -1,0 +1,31 @@
+package com.hanium.diarist.domain.emotion.service;
+
+import com.hanium.diarist.domain.emotion.domain.Emotion;
+import com.hanium.diarist.domain.emotion.dto.CreateEmotionRequest;
+import com.hanium.diarist.domain.emotion.dto.CreateEmotionResponse;
+import com.hanium.diarist.domain.emotion.repository.EmotionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class EmotionService {
+    private final EmotionRepository emotionRepository;
+
+    @Transactional
+    public List<CreateEmotionResponse> createEmotions(List<CreateEmotionRequest> createEmotionRequests) {
+
+        ArrayList<CreateEmotionResponse> emotions = new ArrayList<>();
+        for (CreateEmotionRequest request : createEmotionRequests) {
+            Emotion emotion = request.toEmotionEntity();// request를 감정 객체로 변환
+            emotionRepository.save(emotion);// emotion DB에 저장
+            emotions.add(CreateEmotionResponse.of(emotion));
+        }
+        return emotions;
+    }
+}


### PR DESCRIPTION
## Jira 티켓

[PROJ-103](https://hanium.atlassian.net/browse/PROJ-103)

## 제목

감정 테이블 생성 및 감정 등록 로직 구현

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 감정 테이블 없었음
- 감정 추가 불가


## 변경 후

- 감정 테이블 생성
- 감정 추가 로직 구현
- 감정 이미지는 임의로 넣음
<img width="624" alt="image" src="https://github.com/hanium-4ward/Diarist/assets/110653633/8169b4bd-f41a-4db6-8d5c-fb59c209ee0b">
