### PR TITLE
feat :  PROJ-104 : 카프카를 통한 ai 서버에 그림일기 요청 메세지큐 전송 로직 구현

### DIFF
--- a/server/Spring/.gitignore
+++ b/server/Spring/.gitignore
@@ -5,6 +5,10 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 .env
+/src/main/resources/application-test.yml
+
+
+
 
 ### STS ###
 .apt_generated

--- a/server/Spring/build.gradle
+++ b/server/Spring/build.gradle
@@ -29,12 +29,16 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'io.github.cdimascio:dotenv-java:2.2.0'// .env 파일을 사용하기 위한 라이브러리
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0' // swagger 추가를 위한 의존성
     testImplementation 'com.h2database:h2'  // H2 데이터베이스 의존성 추가
-    //    implementation 'org.springframework.kafka:spring-kafka'
-//    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    implementation 'org.springframework.kafka:spring-kafka'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+
+    implementation 'com.fasterxml.jackson.core:jackson-databind'// jackson 라이브러리 추가 ( json 파싱 )
+
 }
 
 tasks.named('test') {

--- a/server/Spring/src/main/java/com/hanium/diarist/common/config/KafkaProducerConfig.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/config/KafkaProducerConfig.java
@@ -1,0 +1,34 @@
+package com.hanium.diarist.common.config;
+
+import com.fasterxml.jackson.databind.ser.std.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/common/config/KafkaProducerConfig.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/config/KafkaProducerConfig.java
@@ -1,6 +1,6 @@
 package com.hanium.diarist.common.config;
 
-import com.fasterxml.jackson.databind.ser.std.StringSerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.springframework.context.annotation.Bean;
@@ -15,7 +15,7 @@ import java.util.Map;
 @Configuration
 public class KafkaProducerConfig {
 
-    @Value("${spring.kafka.bootstrap-servers}")
+    @Value("${kafka.bootstrap-servers}")
     private String bootstrapServers;
 
     @Bean

--- a/server/Spring/src/main/java/com/hanium/diarist/common/config/WebConfig.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/config/WebConfig.java
@@ -14,8 +14,10 @@ public class WebConfig  implements WebMvcConfigurer {
                         "http://localhost:8081", // 리액트 네이티브 에뮬레이터 (iOS)
 //                        "http://<YOUR_DEVICE_IP>:8081", // 실제 디바이스의 IP 주소와 포트
                         "http://localhost:8000", // 장고 서버
-                        "http://localhost:8080/swagger-ui/index.html"
+                        "http://localhost:8080/swagger-ui/index.html",
 //                        "http://<YOUR_DJANGO_SERVER_IP>:8000" // 장고 서버 IP 주소
+                        "http://localhost:9092", // kafka 서버
+                        "http://localhost:2181" // zookeeper 서버
                 )
                 .allowedMethods("GET", "POST", "PUT", "DELETE")
                 .allowedHeaders("*")

--- a/server/Spring/src/main/java/com/hanium/diarist/common/config/WebConfig.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/config/WebConfig.java
@@ -18,6 +18,7 @@ public class WebConfig  implements WebMvcConfigurer {
 //                        "http://<YOUR_DJANGO_SERVER_IP>:8000" // 장고 서버 IP 주소
                         "http://localhost:9092", // kafka 서버
                         "http://localhost:2181" // zookeeper 서버
+
                 )
                 .allowedMethods("GET", "POST", "PUT", "DELETE")
                 .allowedHeaders("*")

--- a/server/Spring/src/main/java/com/hanium/diarist/common/validator/DiaryDateValidator.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/validator/DiaryDateValidator.java
@@ -1,0 +1,28 @@
+package com.hanium.diarist.common.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+
+public class DiaryDateValidator implements ConstraintValidator<ValidDiaryDate, LocalDate>{
+    private static final Logger logger = LoggerFactory.getLogger(DiaryDateValidator.class);
+
+    @Override
+    public void initialize(ValidDiaryDate constraintAnnotation) {
+
+    }
+
+    @Override
+    public boolean isValid(LocalDate diaryDate, ConstraintValidatorContext context) {
+        if (diaryDate == null) {
+            return true;
+        }
+        LocalDate serverDate = LocalDate.now().plusDays(1);
+        boolean isValid = !diaryDate.isAfter(serverDate);
+        logger.debug("DiaryDateValidator date ={}, isValid: {}",diaryDate,isValid);
+        return isValid;
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/common/validator/ValidDiaryDate.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/validator/ValidDiaryDate.java
@@ -1,0 +1,21 @@
+package com.hanium.diarist.common.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = DiaryDateValidator.class)
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidDiaryDate {
+
+    String message() default "내일보다 먼 날짜는 입력할 수 없습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}
+
+

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/controller/DiaryController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/controller/DiaryController.java
@@ -1,0 +1,54 @@
+package com.hanium.diarist.domain.diary.controller;
+
+import com.hanium.diarist.domain.diary.dto.AdResponse;
+import com.hanium.diarist.domain.diary.dto.CreateDiaryRequest;
+import com.hanium.diarist.domain.diary.service.CreateDiaryConsumerService;
+import com.hanium.diarist.domain.diary.service.CreateDiaryProducerService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.apache.catalina.connector.Response;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.concurrent.Executors;
+
+@RestController
+@RequestMapping("/api/v1/diary")
+@Tag(name = "Diary", description = "일기 API")
+@Validated
+@RequiredArgsConstructor
+public class DiaryController {
+
+    private final CreateDiaryProducerService createDiaryProducerService;
+    private final CreateDiaryConsumerService createDiaryConsumerService;
+
+    @PostMapping("/create")
+    @Operation(summary = "일기 생성 요청", description = "일기 생성 요청 API.")
+    @ApiResponse(responseCode = "200", description = "일기 생성 요청 메세지큐에 등록 완료")
+    @ApiResponse(responseCode = "400", description = "잘못된 요청")
+    public ResponseEntity<String> createDiary(@Valid @RequestBody CreateDiaryRequest createDiaryRequest) {
+        createDiaryProducerService.sendCreateDiaryMessage(createDiaryRequest);
+        return new ResponseEntity<>("일기 생성 요청 메세지큐에 등록 완료", HttpStatus.OK);
+    }
+
+    @PostMapping
+    @Operation(summary = "광고 시청", description = "광고 시청 API.")
+    public AdResponse createDiaryWithAd(@Valid @RequestBody CreateDiaryRequest createDiaryRequest) {
+        boolean adRequired = createDiaryProducerService.sendCreateDiaryMessageWithAd(createDiaryRequest);
+        return new AdResponse(adRequired); // 광고 시청 필요 여부 반환
+    }
+
+
+
+
+
+
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Diary.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Diary.java
@@ -1,0 +1,90 @@
+package com.hanium.diarist.domain.diary.domain;
+
+
+import com.hanium.diarist.common.entity.BaseEntityWithUpdate;
+import com.hanium.diarist.domain.artist.domain.Artist;
+import com.hanium.diarist.domain.emotion.domain.Emotion;
+import com.hanium.diarist.domain.user.domain.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "deleted_at is null") // deleted_at 이 null 인 것만 조회
+public class Diary extends BaseEntityWithUpdate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long diaryId;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "user_id",nullable = false)
+    private User user;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "emotion_id",nullable = false)
+    private Emotion emotion;
+
+    @NotNull
+    @ManyToOne
+    @JoinColumn(name = "artist_id",nullable = false)
+    private Artist artist;
+
+    @Column(nullable = false)
+    private LocalDateTime diaryDate;
+
+    @Column(length = 8013)
+    private String content;
+
+    private LocalDateTime deletedAt;
+
+    @NotNull
+    private boolean isFavorite;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "image_id")
+    private Image image;
+
+
+    public Diary(User user, Emotion emotion, Artist artist, LocalDateTime diaryDate, String content, boolean isFavorite, Image image) {
+        this.user = user;
+        this.emotion = emotion;
+        this.artist = artist;
+        this.diaryDate = diaryDate;
+        this.content = content;
+        this.isFavorite = isFavorite;
+        this.image = null;
+    }
+
+    public void setEmotion(Emotion emotion) {
+        this.emotion = emotion;
+    }
+
+    public void setArtist(Artist artist) {
+        this.artist = artist;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public void setDeletedAt(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
+    }
+
+    public void setFavorite(boolean favorite) {
+        isFavorite = favorite;
+    }
+
+    public void setImage(Image image) {
+        this.image = image;
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Image.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Image.java
@@ -1,0 +1,33 @@
+package com.hanium.diarist.domain.diary.domain;
+
+import com.hanium.diarist.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long imageId;
+
+    @NotNull
+    @OneToOne(mappedBy = "image")
+    private Diary diary;
+
+    @NotNull
+    @Column(nullable = false)
+    private String imageUrl;
+
+    // 프롬프트 일단 생략
+
+
+
+
+
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/AdResponse.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/AdResponse.java
@@ -1,0 +1,13 @@
+package com.hanium.diarist.domain.diary.dto;
+
+public class AdResponse {
+    private boolean adRequired;
+
+    public AdResponse(boolean adRequired) {
+        this.adRequired = adRequired;
+    }
+
+    public boolean isAdRequired() {
+        return adRequired;
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/CreateDiaryRequest.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/CreateDiaryRequest.java
@@ -1,0 +1,49 @@
+package com.hanium.diarist.domain.diary.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.hanium.diarist.common.validator.ValidDiaryDate;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Schema(description = "일기 생성 요청")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CreateDiaryRequest {
+
+    @NotNull
+    @Schema(description = "유저 ID")
+    private Long userId;
+
+    @NotNull
+    @Schema(description = "감정 ID")
+    private Long emotionId;
+
+    @NotNull
+    @Schema(description = "화가 ID")
+    private Long artistId;
+
+    @NotNull
+    @ValidDiaryDate
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @JsonSerialize(using = LocalDateSerializer.class)
+    @JsonDeserialize(using = LocalDateDeserializer.class)
+    @Schema(description = "일기 날짜")
+    private LocalDate diaryDate;
+
+    @NotNull
+    @Schema(description = "일기 내용")
+    private String content;
+
+
+
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/repository/DiaryRepository.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/repository/DiaryRepository.java
@@ -1,0 +1,14 @@
+package com.hanium.diarist.domain.diary.repository;
+
+import com.hanium.diarist.domain.diary.domain.Diary;
+import com.hanium.diarist.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+    Optional<Diary> findByUserAndDiaryDate(User user, LocalDate diaryDate);
+    Optional<Diary> findByDiaryId(Integer diaryId);
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/CreateDiaryProducerService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/CreateDiaryProducerService.java
@@ -1,0 +1,72 @@
+package com.hanium.diarist.domain.diary.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hanium.diarist.domain.diary.domain.Diary;
+import com.hanium.diarist.domain.diary.dto.CreateDiaryRequest;
+import com.hanium.diarist.domain.diary.repository.DiaryRepository;
+import com.hanium.diarist.domain.user.domain.User;
+import com.hanium.diarist.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+@Service
+@RequiredArgsConstructor
+public class CreateDiaryProducerService {
+
+    private final KafkaTemplate<String,String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+    private final DiaryRepository diaryRepository;
+    private final UserRepository userRepository;
+    private final String CreateTopicName = "create-diary";
+    private final String reCreateTopicName = "re-create-diary";
+
+
+    public void sendCreateDiaryMessage(CreateDiaryRequest createDiaryRequest) {
+        try {
+            String message = objectMapper.writeValueAsString(createDiaryRequest);
+            kafkaTemplate.send(CreateTopicName, message);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to convert CreateDiaryRequest to JSON", e);
+        }
+    }
+
+    public boolean sendCreateDiaryMessageWithAd(CreateDiaryRequest createDiaryRequest) {
+        LocalDate date = createDiaryRequest.getDiaryDate();// 일기 작성 날짜 가져옴
+        User user = userRepository.findById(createDiaryRequest.getUserId()).orElseThrow();// 해당 유저 찾음
+        Optional<Diary> existingDiary = diaryRepository.findByUserAndDiaryDate(user, date);// 해당 유저의 일기 작성 날짜에 일기가 있는지 확인
+
+        try{
+            String message = objectMapper.writeValueAsString(createDiaryRequest);
+            if (existingDiary.isPresent()|| !date.isEqual(LocalDate.now())) { // 당시 날짜의 일기가 있거나, 과거의 일기를 작성할 경우
+                // 광고 시청 필수
+                kafkaTemplate.send(reCreateTopicName, message);
+                watchAd();
+                return true;
+            }else{// 과거 날짜 일기 작성
+                 kafkaTemplate.send(CreateTopicName, message);
+                 return false;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+
+    @Async
+    public void watchAd() {
+        System.out.println("광고 시청 중");
+    }
+
+}

--- a/server/Spring/src/main/resources/application-dev.yml
+++ b/server/Spring/src/main/resources/application-dev.yml
@@ -14,12 +14,9 @@ spring:
       level:
         org.hibernate.type.descriptor.sql: trace
 
+
 springdoc:
   swagger-ui:
     path: /api-test
     groups-order: DESC
     tags-sorter: alpha
-
-#  paths-to-match:  - 특정 경로만 API 문서를 생성하고 싶을 때 사용
-#    - /api/**
-

--- a/server/Spring/src/main/resources/application-kafka.yml
+++ b/server/Spring/src/main/resources/application-kafka.yml
@@ -1,0 +1,10 @@
+kafka:
+  bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+  consumer:
+    group-id: hanium
+    auto-offset-reset: earliest
+    key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+  producer:
+    key-serializer: org.apache.kafka.common.serialization.StringSerializer
+    value-serializer: org.apache.kafka.common.serialization.StringSerializer

--- a/server/Spring/src/main/resources/application-test.yml
+++ b/server/Spring/src/main/resources/application-test.yml
@@ -1,11 +1,23 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
     driver-class-name: org.h2.Driver
-
     username: sa
-    password:
+    password: password
+  jackson:
+    default-property-inclusion: non_null
+    serialization:
+      fail-on-empty-beans: false
+
   jpa:
     hibernate:
       ddl-auto: create-drop
-    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: true
+
+  h2:
+    console:
+      enabled: true
+kafka:
+  bootstrap-servers: localhost:9092
+
+

--- a/server/Spring/src/main/resources/application.yml
+++ b/server/Spring/src/main/resources/application.yml
@@ -1,25 +1,24 @@
 spring:
+  profiles:
+    active: dev
+    include: kafka
   datasource:
-    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/main
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/default
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
-    show-sql: true
+      ddl-auto: none
+    show-sql: false
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
     logging:
       level:
-        org.hibernate.type.descriptor.sql: trace
+        org.hibernate.type.descriptor.sql: info
 
 springdoc:
   swagger-ui:
     path: /api-test
     groups-order: DESC
     tags-sorter: alpha
-
-#  paths-to-match:  - 특정 경로만 API 문서를 생성하고 싶을 때 사용
-#    - /api/**
-


### PR DESCRIPTION
## Jira 티켓

[PROJ-104](https://hanium.atlassian.net/browse/PROJ-104)

## 제목

카프카를 통한 ai 서버에 그림일기 요청 메세지큐 전송 로직 구현

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 카프카 의존성 없음
- 일기, 이미지 엔티티 없음
- 카프카 메세지큐를 통한 그림일기 요청 api 없음

## 변경 후

- 오늘 첫 작성 / 오늘 일기 고쳐쓰기 / 과거 일기 작성에 따른 광고 시청 여부 제공 
- kafka 를 통한 메세지큐 구현
- 일기를 저장하는 시점은 django 에서 이미지까지 생성한 이후 저장하면 될 것 같음.

![image](https://github.com/hanium-4ward/Diarist/assets/110653633/61a43e83-8d3e-4de6-935d-3b68f7b67d00)
-> 과거 날짜로 일기를 작성할 경우 false return 

![image](https://github.com/hanium-4ward/Diarist/assets/110653633/ed5515c6-8835-4d7d-a079-508aafa97969)
-> kafka 에 전송된 메세지


[PROJ-104]: https://hanium.atlassian.net/browse/PROJ-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ