### PR TITLE
feat : PROJ-79 : 그림 완성시 클라이언트에게 일기 데이터 제공 api

### DIFF
--- a/server/Spring/src/main/java/com/hanium/diarist/DiaristApplication.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/DiaristApplication.java
@@ -4,9 +4,11 @@ import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 
 @EnableJpaAuditing
+//@EnableScheduling
 @SpringBootApplication
 public class DiaristApplication {
 
@@ -16,6 +18,8 @@ public class DiaristApplication {
         System.setProperty("DB_PORT", dotenv.get("DB_PORT"));
         System.setProperty("DB_USERNAME", dotenv.get("DB_USERNAME"));
         System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
+        System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
+        System.setProperty("KAFKA_BOOTSTRAP_SERVERS", dotenv.get("KAFKA_BOOTSTRAP_SERVERS"));
 
 
         SpringApplication.run(DiaristApplication.class, args);

--- a/server/Spring/src/main/java/com/hanium/diarist/common/config/KafkaConsumerConfig.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/config/KafkaConsumerConfig.java
@@ -1,0 +1,48 @@
+package com.hanium.diarist.common.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaConsumerConfig {
+
+    @Value("${kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, "diary");
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        config.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class.getName());
+        config.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        config.put(JsonDeserializer.VALUE_DEFAULT_TYPE, "java.util.HashMap");
+
+        return new DefaultKafkaConsumerFactory<>(config, new StringDeserializer(),
+                new ErrorHandlingDeserializer<>(new JsonDeserializer<>()));
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        return factory;
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/common/exception/GlobalExceptionHandler.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.hanium.diarist.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors().forEach(error ->
+                errors.put(error.getField(), error.getDefaultMessage()));// 에러가 뜨면 에러가 난 필드에 에러 메세지를 넣어서 return 함
+        return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/artist/controller/ArtistController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/artist/controller/ArtistController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/artist")
+@RequestMapping("/api/v1/artist")
 @RequiredArgsConstructor
 public class ArtistController {
     private final ArtistService artistService;

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/controller/DiaryController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/controller/DiaryController.java
@@ -47,6 +47,32 @@ public class DiaryController {
     }
 
 
+    @GetMapping(value = "/kafka-response",produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter kafkaResponse() {
+        // kafka consumer 가 emitter 에 데이터를 보내면 emitter 가 클라이언트에게 데이터를 보냄
+        return createDiaryConsumerService.addEmitter();
+    }
+
+    @GetMapping(value = "/test-sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter testSse() {
+        SseEmitter emitter = new SseEmitter(3600000L);
+        Executors.newSingleThreadExecutor().execute(() -> {
+            try {
+                for (int i = 0; i < 10; i++) {
+                    emitter.send(SseEmitter.event().data("Test message " + i));
+                    Thread.sleep(1000);
+                }
+                emitter.complete();
+            } catch (Exception e) {
+                emitter.completeWithError(e);
+            }
+        });
+        return emitter;
+    }
+
+
+
+
 
 
 

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Diary.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Diary.java
@@ -10,12 +10,15 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.Where;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Where(clause = "deleted_at is null") // deleted_at 이 null 인 것만 조회
 public class Diary extends BaseEntityWithUpdate {
@@ -39,7 +42,7 @@ public class Diary extends BaseEntityWithUpdate {
     private Artist artist;
 
     @Column(nullable = false)
-    private LocalDateTime diaryDate;
+    private LocalDate diaryDate;
 
     @Column(length = 8013)
     private String content;
@@ -54,7 +57,7 @@ public class Diary extends BaseEntityWithUpdate {
     private Image image;
 
 
-    public Diary(User user, Emotion emotion, Artist artist, LocalDateTime diaryDate, String content, boolean isFavorite, Image image) {
+    public Diary(User user, Emotion emotion, Artist artist, LocalDate diaryDate, String content, boolean isFavorite, Image image) {
         this.user = user;
         this.emotion = emotion;
         this.artist = artist;

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/CreateDiaryResponse.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/CreateDiaryResponse.java
@@ -1,0 +1,41 @@
+package com.hanium.diarist.domain.diary.dto;
+
+import com.hanium.diarist.domain.artist.domain.Artist;
+import com.hanium.diarist.domain.diary.domain.Image;
+import com.hanium.diarist.domain.emotion.domain.Emotion;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Schema(description = "일기 생성 요청")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CreateDiaryResponse {
+
+    private String emotionName;
+    private String emotionPicture;
+    private String content;
+    private String artistName;
+    private String artistPicture;
+    private LocalDate diaryDate;
+    private String ImageUrl;
+
+    @Override
+    public String toString() {
+        return "CreateDiaryResponse{" +
+                "emotionName='" + emotionName + '\'' +
+                ", emotionPicture='" + emotionPicture + '\'' +
+                ", content='" + content + '\'' +
+                ", artistName='" + artistName + '\'' +
+                ", artistPicture='" + artistPicture + '\'' +
+                ", diaryDate=" + diaryDate +
+                ", ImageUrl=" + ImageUrl +
+                '}';
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/CreateDiaryConsumerService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/CreateDiaryConsumerService.java
@@ -1,0 +1,76 @@
+package com.hanium.diarist.domain.diary.service;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hanium.diarist.domain.diary.domain.Diary;
+import com.hanium.diarist.domain.diary.dto.CreateDiaryResponse;
+import com.hanium.diarist.domain.diary.repository.DiaryRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class CreateDiaryConsumerService {
+
+    private final DiaryRepository diaryRepository;
+    private final ObjectMapper objectMapper;
+    private final CopyOnWriteArrayList<SseEmitter> emitters = new CopyOnWriteArrayList<>();// 클라이언트와 sse 연결을 관리하는 리스트
+
+    // 클라이언트가 sse 연결을 요청할 때 새로운 sseEmitter를 생성해 반환함
+    public SseEmitter addEmitter() {
+        SseEmitter emitter = new SseEmitter(60000L);// 타임아웃 시간 60초
+        this.emitters.add(emitter);
+        emitter.onCompletion(() -> this.emitters.remove(emitter));// 연결 완료시 리스트에서 제거
+        emitter.onTimeout(() -> this.emitters.remove(emitter));// 타임아웃시 리스트에서 제거
+        emitter.onError(e -> this.emitters.remove(emitter));// 에러시 리스트에서 제거
+
+
+        return emitter;
+    }
+
+    // 모든 클라이언트에게 메세지를 전송함.
+    private void sendEmitters(CreateDiaryResponse diaryResponse){
+        for (SseEmitter emitter : emitters) {
+            try {
+                String jsonResponse = objectMapper.writeValueAsString(diaryResponse);
+                //System.out.println("Sending to emitter: " + jsonResponse);
+                emitter.send(SseEmitter.event().data(jsonResponse));
+            } catch (Exception e) {
+                this.emitters.remove(emitter);
+            }
+        }
+    }
+
+
+
+    // kafka 의 create-diary-response 토픽에서 메세지를 수신해서 처리함
+    @KafkaListener(topics = "create-diary-response", groupId = "diary")
+    public void consumeCreateDiaryResponse(HashMap<String,Integer> message) {
+        try {
+            Integer diaryId = Integer.parseInt(String.valueOf(message.get("diaryId")));
+            Diary diary = diaryRepository.findByDiaryId(diaryId).orElseThrow(() -> new RuntimeException("일기가 없습니다."));
+            CreateDiaryResponse createDiaryResponse = new CreateDiaryResponse(diary.getEmotion().getEmotionName(),diary.getEmotion().getEmotionPicture(),diary.getContent(),diary.getArtist().getArtistName(),diary.getArtist().getArtistPicture(),diary.getDiaryDate(),diary.getImage().getImageUrl());
+//            System.out.println(createDiaryResponse);
+            sendEmitters(createDiaryResponse);// json 형식으로 변경
+        } catch (Exception e) {
+            System.err.println("Error while consuming message: " + e.getMessage());
+            throw new RuntimeException(e);
+        }
+    }
+
+
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/emotion/controller/EmotionController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/emotion/controller/EmotionController.java
@@ -3,6 +3,7 @@ package com.hanium.diarist.domain.emotion.controller;
 import com.hanium.diarist.domain.emotion.dto.CreateEmotionRequest;
 import com.hanium.diarist.domain.emotion.dto.CreateEmotionResponse;
 import com.hanium.diarist.domain.emotion.service.EmotionService;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +15,8 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/emotion")
+@RequestMapping("/api/v1/emotion")
+@Tag(name = "Emotion", description = "감정 API")
 @RequiredArgsConstructor
 public class EmotionController {
     private final EmotionService emotionService;

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/user/controller/UserController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.hanium.diarist.domain.user.dto.UserRegistrationRequest;
 import com.hanium.diarist.domain.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,7 +14,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/user")
+@RequestMapping("/api/v1/user")
+@Tag(name = "User", description = "유저 API")
 @RequiredArgsConstructor
 public class UserController {
 

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/user/domain/User.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/user/domain/User.java
@@ -36,6 +36,9 @@ public class User extends BaseEntityWithUpdate {
 
     private LocalDateTime deletedAt;
 
+
+
+
     @Builder(access = AccessLevel.PRIVATE)// private 생성자를 만들어줌
     public User(String name, String email, SocialCode socialCode) {
         this.name = name;

--- a/server/Spring/src/test/java/com/hanium/diarist/domain/diary/service/CreateDiaryProducerServiceTest.java
+++ b/server/Spring/src/test/java/com/hanium/diarist/domain/diary/service/CreateDiaryProducerServiceTest.java
@@ -1,0 +1,94 @@
+//package com.hanium.diarist.domain.diary.service;
+//
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.hanium.diarist.domain.diary.dto.CreateDiaryRequest;
+//import com.hanium.diarist.domain.diary.domain.Diary;
+//import com.hanium.diarist.domain.diary.repository.DiaryRepository;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.MockitoAnnotations;
+//import org.springframework.kafka.core.KafkaTemplate;
+//
+//import java.time.LocalDate;
+//import java.util.Optional;
+//
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.Mockito.*;
+//
+//class CreateDiaryProducerServiceTest {
+//
+//    @Mock
+//    private KafkaTemplate<String, String> kafkaTemplate;
+//
+//    @Mock
+//    private ObjectMapper objectMapper;
+//
+//    @Mock
+//    private DiaryRepository diaryRepository;
+//
+//    @InjectMocks
+//    private CreateDiaryProducerService createDiaryProducerService;
+//
+//    @BeforeEach
+//    void setUp() {
+//        MockitoAnnotations.openMocks(this);
+//    }
+//
+//    @Test
+//    void testSendCreateDiaryMessage_FirstTimeToday() throws Exception {
+//        CreateDiaryRequest request = new CreateDiaryRequest();
+//        request.setDate(LocalDate.now());
+//
+//        when(diaryRepository.findByDate(any(LocalDate.class))).thenReturn(Optional.empty());
+//        when(objectMapper.writeValueAsString(any())).thenReturn("testMessage");
+//
+//        createDiaryProducerService.sendCreateDiaryMessage(request);
+//
+//        verify(kafkaTemplate, times(1)).send("create-diary", "testMessage");
+//        verify(kafkaTemplate, never()).send("reCreate-diary", "testMessage");
+//    }
+//
+//    @Test
+//    void testSendCreateDiaryMessage_RecreateToday() throws Exception {
+//        CreateDiaryRequest request = new CreateDiaryRequest();
+//        request.setDate(LocalDate.now());
+//
+//        when(diaryRepository.findByDate(any(LocalDate.class))).thenReturn(Optional.of(new Diary()));
+//        when(objectMapper.writeValueAsString(any())).thenReturn("testMessage");
+//
+//        createDiaryProducerService.sendCreateDiaryMessage(request);
+//
+//        verify(kafkaTemplate, times(1)).send("reCreate-diary", "testMessage");
+//        verify(kafkaTemplate, never()).send("create-diary", "testMessage");
+//    }
+//
+//    @Test
+//    void testSendCreateDiaryMessage_PastDate() throws Exception {
+//        CreateDiaryRequest request = new CreateDiaryRequest();
+//        request.setDate(LocalDate.now().minusDays(1));
+//
+//        when(diaryRepository.findByDate(any(LocalDate.class))).thenReturn(Optional.empty());
+//        when(objectMapper.writeValueAsString(any())).thenReturn("testMessage");
+//
+//        createDiaryProducerService.sendCreateDiaryMessage(request);
+//
+//        verify(kafkaTemplate, times(1)).send("create-diary", "testMessage");
+//        verify(kafkaTemplate, never()).send("reCreate-diary", "testMessage");
+//    }
+//
+//    @Test
+//    void testSendCreateDiaryMessage_RecreatePastDate() throws Exception {
+//        CreateDiaryRequest request = new CreateDiaryRequest();
+//        request.setDate(LocalDate.now().minusDays(1));
+//
+//        when(diaryRepository.findByDate(any(LocalDate.class))).thenReturn(Optional.of(new Diary()));
+//        when(objectMapper.writeValueAsString(any())).thenReturn("testMessage");
+//
+//        createDiaryProducerService.sendCreateDiaryMessage(request);
+//
+//        verify(kafkaTemplate, times(1)).send("reCreate-diary", "testMessage");
+//        verify(kafkaTemplate, never()).send("create-diary", "testMessage");
+//    }
+//}


### PR DESCRIPTION
## Jira 티켓

[PROJ-79](https://hanium.atlassian.net/browse/PROJ-79)

## 제목

그림일기 생성 완료 후 클라이언트에게 일기 데이터 제공 api

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 클라이언트에게 데이터를 제공할 수 없었음.

## 변경 후

- sse ( server-sents events) 를 통해 클라이언트에게 데이터를 제공할 수 있음. 
- topic 이름 : create-diary-response

1. 광고, 로딩을 다 시청 후 , 혹은 이미지를 가져오는 시점에 kafka-response api를 호출한다. 
![image](https://github.com/hanium-4ward/Diarist/assets/110653633/7c49fefe-29fd-4819-a54c-eba868a1f8e7)
2. 그럼 다음과 같이 sse 가 connect 된다. 
3. 이후 django 에서 그림을 생성을 한 후 저장한다. 그리고 일기의 id 를 kafka를 통해 메세지로 보낸다.  ( 예시 사진 ) 
<img width="149" alt="image" src="https://github.com/hanium-4ward/Diarist/assets/110653633/67fd6daf-6f61-4276-a852-64fa2494d460">

4. kafka를 통해 보내진 메세지는 springboot 가 읽고, 해당 메세지를 client 가 필요한 형식으로 바꾸어 sse 에 담아 전송한다.

![image](https://github.com/hanium-4ward/Diarist/assets/110653633/fe76b841-300d-4642-beef-236d9cf022b4)

5. client 는 해당 json 을 읽어 렌더링한다. 





[PROJ-79]: https://hanium.atlassian.net/browse/PROJ-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ