### PR TITLE
feat : PROJ-98 : 즐겨찾기 로직 구현

### DIFF
--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Diary.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Diary.java
@@ -50,20 +50,20 @@ public class Diary extends BaseEntityWithUpdate {
     private LocalDateTime deletedAt;
 
     @NotNull
-    private boolean isFavorite;
+    private boolean favorite;
 
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "image_id")
     private Image image;
 
 
-    public Diary(User user, Emotion emotion, Artist artist, LocalDate diaryDate, String content, boolean isFavorite, Image image) {
+    public Diary(User user, Emotion emotion, Artist artist, LocalDate diaryDate, String content, boolean favorite, Image image) {
         this.user = user;
         this.emotion = emotion;
         this.artist = artist;
         this.diaryDate = diaryDate;
         this.content = content;
-        this.isFavorite = isFavorite;
+        this.favorite = favorite;
         this.image = null;
     }
 
@@ -84,7 +84,7 @@ public class Diary extends BaseEntityWithUpdate {
     }
 
     public void setFavorite(boolean favorite) {
-        isFavorite = favorite;
+        this.favorite = favorite;
     }
 
     public void setImage(Image image) {

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/BookmarkDiaryRequest.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/BookmarkDiaryRequest.java
@@ -1,0 +1,15 @@
+package com.hanium.diarist.domain.diary.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BookmarkDiaryRequest {
+
+        private Long diaryId;
+        private boolean favorite;
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/BookmarkDiaryResponse.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/BookmarkDiaryResponse.java
@@ -1,0 +1,22 @@
+package com.hanium.diarist.domain.diary.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Schema(description = "일기 즐겨찾기 응답값")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class BookmarkDiaryResponse {
+
+        @Schema(description = "일기 ID")
+        private Long diaryId;
+
+        @Schema(description = "즐겨찾기 여부")
+        private boolean favorite;
+
+
+
+
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/repository/DiaryRepository.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/repository/DiaryRepository.java
@@ -10,5 +10,6 @@ import java.util.Optional;
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     Optional<Diary> findByUserAndDiaryDate(User user, LocalDate diaryDate);
-    Optional<Diary> findByDiaryId(Integer diaryId);
+    Optional<Diary> findByDiaryId(long diaryId);
+
 }

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/DiaryService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/DiaryService.java
@@ -1,0 +1,46 @@
+package com.hanium.diarist.domain.diary.service;
+
+import com.hanium.diarist.domain.diary.domain.Diary;
+import com.hanium.diarist.domain.diary.dto.BookmarkDiaryResponse;
+import com.hanium.diarist.domain.diary.repository.DiaryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DiaryService {
+    private final DiaryRepository diaryRepository;
+
+    @Transactional
+    public BookmarkDiaryResponse bookmarkDiary(Long diaryId, boolean favorite) {
+        Optional<Diary> diary = diaryRepository.findByDiaryId(diaryId);
+        if(!diary.isPresent()){
+            throw new IllegalArgumentException("해당 일기가 존재하지 않습니다." + diaryId);
+        }
+        Diary updateDiary = diary.get();
+        updateDiary.setFavorite(favorite);
+        Diary saved = diaryRepository.save(updateDiary);
+        return new BookmarkDiaryResponse(saved.getDiaryId(),saved.isFavorite());
+    }
+
+    @Transactional
+    public List<BookmarkDiaryResponse> deleteBookmarkDiary(List<Long> diaryIdList) {
+        List<Diary> diaries = diaryRepository.findAllById(diaryIdList);
+        diaries.forEach(diary -> diary.setFavorite(false)); // 즐겨 찾기 해제
+        List<Diary> updatedDiaries = diaryRepository.saveAll(diaries);
+        return updatedDiaries.stream()
+                .map(diary -> new BookmarkDiaryResponse(diary.getDiaryId(), diary.isFavorite()))
+                .collect(Collectors.toList());
+    }
+
+
+}
+
+
+
+


### PR DESCRIPTION
## Jira 티켓

[PROJ-98](https://hanium.atlassian.net/browse/PROJ-98)

## 제목

즐겨찾기 로직 구현

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 즐겨 찾기 로직 미 구현, 
- 즐겨찾기 필드 명 isFavorite ( is_favorite)
- DiaryRepository 의 `Optional<Diary> findByDiaryId(Integer diaryId);` 부분 파라미터 Integer 

## 변경 후

- 일기 1개에 대한 즐겨찾기 로직
- 일기 여러개를 즐겨찾기 해제하는 로직

---

### refactor
- Diary 의 diaryId 의 범위가 long 이기 때문에 DiaryRepository의 findByDiaryId의 파라미터를 long 으로 변경
- java에서 boolean 값에 대해 is로 필드명이 시작한다면 get을 호출할 때 isFavorite 으로 호출해야 하기 때문에 필드명의 혼선이 있을것을 방지하고자 isFavorite 필드명을 favorite 으로 변경함. 

---

* 일기 여러개 즐겨찾기에서 해제 ( 앨범페이지에서 사용할 api ) 
<img width="1069" alt="image" src="https://github.com/hanium-4ward/Diarist/assets/110653633/127b9eb0-8168-46a7-8ecd-18e007d67bc8">

* 일기 즐겨찾기 등록 및 해제 ( 상세페이지, 확인페이지에서 사용할 api )
<img width="1096" alt="image" src="https://github.com/hanium-4ward/Diarist/assets/110653633/8adf236b-2dac-4574-a645-d9181046dc6d">



[PROJ-98]: https://hanium.atlassian.net/browse/PROJ-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ