### PR TITLE
refactor : PROJ-113 : 일기 생성 완료 메세지를 받아 클라이언트에게 제공하는 로직 수정

### DIFF
--- a/server/Spring/src/main/java/com/hanium/diarist/common/exception/BusinessException.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/exception/BusinessException.java
@@ -1,0 +1,20 @@
+package com.hanium.diarist.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, Throwable throwable) {
+        super(errorCode.getMessage(), throwable);
+        this.errorCode = errorCode;
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/common/exception/ErrorCode.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/exception/ErrorCode.java
@@ -1,0 +1,35 @@
+package com.hanium.diarist.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@Getter
+public enum ErrorCode {
+
+    // Common
+    KAFKFA_CONNECT_ERROR(500, "C001", "Kafka 연결 중 오류가 발생했습니다."),
+
+    // User
+
+
+    // Diary
+    DIARY_NOT_FOUND(404, "D001", "일기를 찾을 수 없습니다."),
+    INVALID_DIARY_ID(400, "D002", "일기 ID 형식이 잘못되었습니다."),
+    JSON_PROCESS_ERROR(500, "D003", "JSON 처리 중 오류가 발생했습니다."),
+    SSE_ERROR(500, "D004", "SSE 처리 중 오류가 발생했습니다.");
+
+    // Emotion
+
+    // Image
+
+    private final int status;// HTTP 상태코드
+    private final String code; // 에러 코드
+    private final String message; // 에러 메시지
+
+    ErrorCode(int status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/common/exception/GlobalExceptionHandler.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/exception/GlobalExceptionHandler.java
@@ -1,21 +1,66 @@
 package com.hanium.diarist.common.exception;
 
+import com.hanium.diarist.common.response.ErrorResponse;
+import com.hanium.diarist.domain.diary.exception.KafkaConnectException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
-    @ExceptionHandler(MethodArgumentNotValidException.class)
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<Object> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        if (errorCode.getStatus() == HttpStatus.INTERNAL_SERVER_ERROR.value()) {
+            log.error("handleBusinessException", e);
+        }else{
+            log.warn("handleBusinessException", e);
+        }
+        return handleExceptionInternal(errorCode);
+    }
+
+
+    @ExceptionHandler(KafkaConnectException.class)
+    public ResponseEntity<Object> handleKafkaConnectException(KafkaConnectException e) {
+        log.error("handleKafkaConnectException", e);
+        return new ResponseEntity<>(e.getMessage(), HttpStatus.SERVICE_UNAVAILABLE);
+    }
+
+
+    @ExceptionHandler(MethodArgumentNotValidException.class) // 메서드 인자가 잘못됐을 때 발생하는 예외 (valid 어노테이션을 사용했을 때)
     public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
         Map<String, String> errors = new HashMap<>();
         ex.getBindingResult().getFieldErrors().forEach(error ->
                 errors.put(error.getField(), error.getDefaultMessage()));// 에러가 뜨면 에러가 난 필드에 에러 메세지를 넣어서 return 함
         return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
     }
+
+
+
+
+
+    /// 에러 코드를 받아서 에러 메세지를 반환하는 함수
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(makeErrorResponse(errorCode));
+    }
+
+
+    // errorResponse를 만드는 함수
+    private ErrorResponse makeErrorResponse(ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .code(errorCode.getCode())
+                .message(errorCode.getMessage())
+                .build();
+    }
+
 }

--- a/server/Spring/src/main/java/com/hanium/diarist/common/response/ErrorResponse.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/response/ErrorResponse.java
@@ -1,0 +1,38 @@
+package com.hanium.diarist.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class ErrorResponse {
+
+    private final boolean status = false;
+    private final String code;
+    private final String message;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<ValidationError> errors;
+
+    @Getter
+    @Builder
+    @RequiredArgsConstructor
+    public static class ValidationError {
+
+        private final String field;
+        private final String message;
+
+        public static ValidationError of(final FieldError fieldError) {
+            return ValidationError.builder()
+                    .field(fieldError.getField())
+                    .message(fieldError.getDefaultMessage())
+                    .build();
+        }
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Diary.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Diary.java
@@ -32,12 +32,12 @@ public class Diary extends BaseEntityWithUpdate {
     private User user;
 
     @NotNull
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "emotion_id",nullable = false)
     private Emotion emotion;
 
     @NotNull
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "artist_id",nullable = false)
     private Artist artist;
 
@@ -52,7 +52,7 @@ public class Diary extends BaseEntityWithUpdate {
     @NotNull
     private boolean favorite;
 
-    @OneToOne(cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY,cascade = CascadeType.ALL)
     @JoinColumn(name = "image_id")
     private Image image;
 

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Image.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Image.java
@@ -17,7 +17,7 @@ public class Image extends BaseEntity {
     private Long imageId;
 
     @NotNull
-    @OneToOne(mappedBy = "image")
+    @OneToOne(mappedBy = "image",fetch = FetchType.LAZY)
     private Diary diary;
 
     @NotNull

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/exception/DiaryIdInvalidException.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/exception/DiaryIdInvalidException.java
@@ -1,0 +1,10 @@
+package com.hanium.diarist.domain.diary.exception;
+
+import com.hanium.diarist.common.exception.BusinessException;
+import com.hanium.diarist.common.exception.ErrorCode;
+
+public class DiaryIdInvalidException extends BusinessException {
+    public DiaryIdInvalidException() {
+        super(ErrorCode.INVALID_DIARY_ID);
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/exception/DiaryNotFoundException.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/exception/DiaryNotFoundException.java
@@ -1,0 +1,11 @@
+package com.hanium.diarist.domain.diary.exception;
+
+import com.hanium.diarist.common.exception.BusinessException;
+import com.hanium.diarist.common.exception.ErrorCode;
+
+public class DiaryNotFoundException extends BusinessException {
+    public DiaryNotFoundException() {
+        super(ErrorCode.DIARY_NOT_FOUND);
+    }
+
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/exception/JsonProcessException.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/exception/JsonProcessException.java
@@ -1,0 +1,10 @@
+package com.hanium.diarist.domain.diary.exception;
+
+import com.hanium.diarist.common.exception.BusinessException;
+import com.hanium.diarist.common.exception.ErrorCode;
+
+public class JsonProcessException extends BusinessException {
+    public JsonProcessException() {
+        super(ErrorCode.JSON_PROCESS_ERROR);
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/exception/KafkaConnectException.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/exception/KafkaConnectException.java
@@ -1,0 +1,13 @@
+package com.hanium.diarist.domain.diary.exception;
+
+import com.hanium.diarist.common.exception.BusinessException;
+import com.hanium.diarist.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+public class KafkaConnectException extends BusinessException {
+    public KafkaConnectException() {
+        super(ErrorCode.KAFKFA_CONNECT_ERROR);
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/exception/SseException.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/exception/SseException.java
@@ -1,0 +1,10 @@
+package com.hanium.diarist.domain.diary.exception;
+
+import com.hanium.diarist.common.exception.BusinessException;
+import com.hanium.diarist.common.exception.ErrorCode;
+
+public class SseException extends BusinessException {
+    public SseException() {
+        super(ErrorCode.SSE_ERROR);
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/repository/DiaryRepository.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/repository/DiaryRepository.java
@@ -3,6 +3,7 @@ package com.hanium.diarist.domain.diary.repository;
 import com.hanium.diarist.domain.diary.domain.Diary;
 import com.hanium.diarist.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -11,5 +12,8 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     Optional<Diary> findByUserAndDiaryDate(User user, LocalDate diaryDate);
     Optional<Diary> findByDiaryId(long diaryId);
+
+    @Query("select d from Diary d join fetch d.emotion join fetch d.artist join fetch d.image where d.diaryId = :diaryId")
+    Optional<Diary> findByDiaryIdWithDetails(long diaryId);
 
 }

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/CreateDiaryConsumerService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/CreateDiaryConsumerService.java
@@ -61,7 +61,7 @@ public class CreateDiaryConsumerService {
     @KafkaListener(topics = "create-diary-response", groupId = "diary")
     public void consumeCreateDiaryResponse(HashMap<String,Integer> message) {
         try {
-            Integer diaryId = Integer.parseInt(String.valueOf(message.get("diaryId")));
+            long diaryId = Long.parseLong(String.valueOf(message.get("diaryId")));
             Diary diary = diaryRepository.findByDiaryId(diaryId).orElseThrow(() -> new RuntimeException("일기가 없습니다."));
             CreateDiaryResponse createDiaryResponse = new CreateDiaryResponse(diary.getEmotion().getEmotionName(),diary.getEmotion().getEmotionPicture(),diary.getContent(),diary.getArtist().getArtistName(),diary.getArtist().getArtistPicture(),diary.getDiaryDate(),diary.getImage().getImageUrl());
 //            System.out.println(createDiaryResponse);


### PR DESCRIPTION
## Jira 티켓

[PROJ-113](https://hanium.atlassian.net/browse/PROJ-113)

## 제목

일기 생성 완료 메세지를 받아 클라이언트에게 제공하는 로직 수정

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

1.  Diary entity : eager loading으로 일기를 불러올 때 연관된 모든 엔티티를 불러왔음 
    * 일기값을 불러올 때 당시 즉시 로딩으로 불러왔음.  
2. kafkaConsumer 일기 id 값 Integer 로 받았음
3. 예외 처리 코드 없음


## 변경 후

1. fetch = FetchType.lazy 으로 지연로딩으로 연관 엔티티가 실제로 필요할 때 불러올 수 있도록 하여 최적화함. 
    *   지연로딩으로 바뀌었기 때문에 consumer 의  
    `CreateDiaryResponse createDiaryResponse = new CreateDiaryResponse(diary.getEmotion().getEmotionName(), diary.getEmotion().getEmotionPicture(), diary.getContent(), diary.getArtist().getArtistName(), diary.getArtist().getArtistPicture(), diary.getDiaryDate(), diary.getImage().getImageUrl());`
    부분에서 쿼리가 여러번 호출되게 된다. 때문에 해당 부분을 즉시로딩으로 바꾸기 위해 JPQL을 사용함.
      ``` java 
      @Query("select d from Diary d join fetch d.emotion join fetch d.artist join fetch d.image where d.diaryId = :diaryId")
    Optional<Diary> findByDiaryIdWithDetails(long diaryId);
    ```
    -> 즉시로딩으로 변경
2. diaryId가 엔티티 내의 값이 long이기 때문에 long으로 받는것으로 수정. 
3. 예외 처리 코드 추가. ( 보완 필요 ) 


[PROJ-113]: https://hanium.atlassian.net/browse/PROJ-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ