### PR TITLE
refactor : PROJ-114 : 일기 생성 요청을 kafka에 보내는 로직 리팩토링

### DIFF
--- a/server/Spring/src/main/java/com/hanium/diarist/common/response/SuccessResponse.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/response/SuccessResponse.java
@@ -1,0 +1,32 @@
+package com.hanium.diarist.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.*;
+
+@Getter
+@Schema(description = "성공 Response")
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SuccessResponse<T> {
+    @Schema(description = "성공 여부, 항상 true", defaultValue = "true")
+    private final boolean status = true;
+
+    @JsonInclude(Include.NON_NULL)
+    private T data;
+
+    public static <T> SuccessResponse<T> of(T data) {
+        SuccessResponse<T> response = new SuccessResponse<>();
+        response.data = data;
+        return response;
+    }
+    public ResponseEntity<SuccessResponse<T>> asHttp(HttpStatus httpStatus) {
+        return ResponseEntity.status(httpStatus).body(this);
+    }
+
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/common/validator/DiaryDateValidator.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/validator/DiaryDateValidator.java
@@ -20,7 +20,7 @@ public class DiaryDateValidator implements ConstraintValidator<ValidDiaryDate, L
         if (diaryDate == null) {
             return true;
         }
-        LocalDate serverDate = LocalDate.now().plusDays(1);
+        LocalDate serverDate = LocalDate.now();
         boolean isValid = !diaryDate.isAfter(serverDate);
         logger.debug("DiaryDateValidator date ={}, isValid: {}",diaryDate,isValid);
         return isValid;

--- a/server/Spring/src/main/java/com/hanium/diarist/common/validator/ValidDiaryDate.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/validator/ValidDiaryDate.java
@@ -11,7 +11,7 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ValidDiaryDate {
 
-    String message() default "내일보다 먼 날짜는 입력할 수 없습니다.";
+    String message() default "오늘보다 먼 날짜는 입력할 수 없습니다.";
 
     Class<?>[] groups() default {};
 

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/artist/controller/ArtistController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/artist/controller/ArtistController.java
@@ -1,5 +1,6 @@
 package com.hanium.diarist.domain.artist.controller;
 
+import com.hanium.diarist.common.response.SuccessResponse;
 import com.hanium.diarist.domain.artist.domain.Period;
 import com.hanium.diarist.domain.artist.dto.ArtistFilterByPeriodResponse;
 import com.hanium.diarist.domain.artist.dto.CreateArtistRequest;
@@ -19,14 +20,16 @@ public class ArtistController {
     private final ArtistService artistService;
 
     @PostMapping("/create")
-    public ResponseEntity<List<CreateArtistResponse>> createArtists(@RequestBody List<CreateArtistRequest> createArtistRequests) {
+    public ResponseEntity<SuccessResponse<List<CreateArtistResponse>>> createArtists(@RequestBody List<CreateArtistRequest> createArtistRequests) {
         List<CreateArtistResponse> artists = artistService.createArtists(createArtistRequests);
-        return new ResponseEntity<>(artists, HttpStatus.CREATED);
+        return SuccessResponse.of(artists).asHttp(HttpStatus.CREATED);
+
     }
 
     @GetMapping("/list")
-    public ResponseEntity<List<ArtistFilterByPeriodResponse>> getArtistsFilterByPeriod(@RequestParam Period period) {
+    public ResponseEntity<SuccessResponse<List<ArtistFilterByPeriodResponse>>> getArtistsFilterByPeriod(@RequestParam Period period) {
         List<ArtistFilterByPeriodResponse> artists = artistService.filterByPeriod(period);
-        return new ResponseEntity<>(artists, HttpStatus.OK);
+        return SuccessResponse.of(artists).asHttp(HttpStatus.OK);
+
     }
 }

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/controller/DiaryController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/controller/DiaryController.java
@@ -1,5 +1,6 @@
 package com.hanium.diarist.domain.diary.controller;
 
+import com.hanium.diarist.common.response.SuccessResponse;
 import com.hanium.diarist.domain.diary.dto.AdResponse;
 import com.hanium.diarist.domain.diary.dto.BookmarkDiaryRequest;
 import com.hanium.diarist.domain.diary.dto.BookmarkDiaryResponse;
@@ -46,9 +47,9 @@ public class DiaryController {
 
     @PostMapping
     @Operation(summary = "광고 시청", description = "광고 시청 API.")
-    public AdResponse createDiaryWithAd(@Valid @RequestBody CreateDiaryRequest createDiaryRequest) {
+    public SuccessResponse<AdResponse> createDiaryWithAd(@Valid @RequestBody CreateDiaryRequest createDiaryRequest) {
         boolean adRequired = createDiaryProducerService.sendCreateDiaryMessageWithAd(createDiaryRequest);
-        return new AdResponse(adRequired); // 광고 시청 필요 여부 반환
+        return SuccessResponse.of(new AdResponse(adRequired));// 광고 시청 여부 반환
     }
 
 
@@ -60,16 +61,16 @@ public class DiaryController {
 
     @PostMapping("/bookmark")
     @Operation(summary = "일기 즐겨찾기 (1개)", description = "일기 즐겨찾기 API.")
-    public ResponseEntity<BookmarkDiaryResponse> bookmarkDiary(@RequestBody BookmarkDiaryRequest request) {
+    public ResponseEntity<SuccessResponse<BookmarkDiaryResponse>> bookmarkDiary(@RequestBody BookmarkDiaryRequest request) {
         BookmarkDiaryResponse response = diaryService.bookmarkDiary(request.getDiaryId(), request.isFavorite());
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        return SuccessResponse.of(response).asHttp(HttpStatus.OK);
     }
 
     @PostMapping("/bookmark/delete")
     @Operation(summary = "일기 즐겨찾기 해제", description = "앨범페이지 일기 즐겨찾기 해제 API")
-    public ResponseEntity<List<BookmarkDiaryResponse>> deleteBookmarkDiary(@RequestBody List<Long> diaryIdList) {
+    public ResponseEntity<SuccessResponse<List<BookmarkDiaryResponse>>> deleteBookmarkDiary(@RequestBody List<Long> diaryIdList) {
         List<BookmarkDiaryResponse> bookmarkDiaryResponses = diaryService.deleteBookmarkDiary(diaryIdList);
-        return new ResponseEntity<>(bookmarkDiaryResponses, HttpStatus.OK);
+        return SuccessResponse.of(bookmarkDiaryResponses).asHttp(HttpStatus.OK);
     }
 
 

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/DiaryService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/DiaryService.java
@@ -2,6 +2,7 @@ package com.hanium.diarist.domain.diary.service;
 
 import com.hanium.diarist.domain.diary.domain.Diary;
 import com.hanium.diarist.domain.diary.dto.BookmarkDiaryResponse;
+import com.hanium.diarist.domain.diary.exception.DiaryNotFoundException;
 import com.hanium.diarist.domain.diary.repository.DiaryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,7 +21,7 @@ public class DiaryService {
     public BookmarkDiaryResponse bookmarkDiary(Long diaryId, boolean favorite) {
         Optional<Diary> diary = diaryRepository.findByDiaryId(diaryId);
         if(!diary.isPresent()){
-            throw new IllegalArgumentException("해당 일기가 존재하지 않습니다." + diaryId);
+            throw new DiaryNotFoundException();
         }
         Diary updateDiary = diary.get();
         updateDiary.setFavorite(favorite);

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/emotion/controller/EmotionController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/emotion/controller/EmotionController.java
@@ -1,5 +1,6 @@
 package com.hanium.diarist.domain.emotion.controller;
 
+import com.hanium.diarist.common.response.SuccessResponse;
 import com.hanium.diarist.domain.emotion.dto.CreateEmotionRequest;
 import com.hanium.diarist.domain.emotion.dto.CreateEmotionResponse;
 import com.hanium.diarist.domain.emotion.service.EmotionService;
@@ -22,9 +23,9 @@ public class EmotionController {
     private final EmotionService emotionService;
 
     @PostMapping("/create")
-    public ResponseEntity<List<CreateEmotionResponse>> createEmotions(@RequestBody List<CreateEmotionRequest> createEmotionRequests) {
+    public ResponseEntity<SuccessResponse<List<CreateEmotionResponse>>> createEmotions(@RequestBody List<CreateEmotionRequest> createEmotionRequests) {
         List<CreateEmotionResponse> emotions = emotionService.createEmotions(createEmotionRequests);
-        return new ResponseEntity<>(emotions, HttpStatus.CREATED);
+        return SuccessResponse.of(emotions).asHttp(HttpStatus.CREATED);
     }
 
 }


### PR DESCRIPTION
## Jira 티켓

[PROJ-114](https://hanium.atlassian.net/browse/PROJ-114)

## 제목

일기 생성 요청을 kafka에 보내는 로직 리팩토링

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 카프카 producer 에 대한 예외처리 없음
- 성공 Response, 예외처리 response 에 대한 형태를 지정하지 않음
- 일기 날짜가 내일 일기가 작성되는 오류

## 변경 후

- 카프카 producer에 대한 예외 처리 추가. ( 보완 필요 ) 
- 오늘까지의 날짜까지만 일기가 작성될 수 있도록 hot fix
- 성공 Reponse, 예외처리에 대한 response 를 지정. 
    - 성공시 status, data 를 제공
    - 실패시 status와 예외처리  code와 message 제공

* 성공 처리시 제공되는 json
<img width="950" alt="image" src="https://github.com/hanium-4ward/Diarist/assets/110653633/8305272f-d7fb-40f3-bf8f-015f952035a9">

* 실패시 제공되는 json
<img width="970" alt="image" src="https://github.com/hanium-4ward/Diarist/assets/110653633/5f2cc532-8d0b-4ac5-a5ff-2f2e6ccd50f0">


[PROJ-114]: https://hanium.atlassian.net/browse/PROJ-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ