### PR TITLE
refactor : PROJ-115 : 일기 생성 요청을 kafka에 보내는 로직의 Test Code 작성

### DIFF
--- a/server/Spring/build.gradle
+++ b/server/Spring/build.gradle
@@ -28,16 +28,28 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // 환경 설정 및 swagger 추가
     implementation 'io.github.cdimascio:dotenv-java:2.2.0'// .env 파일을 사용하기 위한 라이브러리
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0' // swagger 추가를 위한 의존성
+
     testImplementation 'com.h2database:h2'  // H2 데이터베이스 의존성 추가
+
+    // kafka
     implementation 'org.springframework.kafka:spring-kafka'
-    testImplementation 'org.springframework.kafka:spring-kafka-test'
+
 
     implementation 'com.fasterxml.jackson.core:jackson-databind'// jackson 라이브러리 추가 ( json 파싱 )
+
+    // testcode
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.mockito:mockito-junit-jupiter'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+
 
 }
 

--- a/server/Spring/src/main/java/com/hanium/diarist/common/exception/ErrorCode.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/exception/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
 
     // Common
     KAFKFA_CONNECT_ERROR(500, "C001", "Kafka 연결 중 오류가 발생했습니다."),
+    JSON_PROCESS_ERROR(500, "C003", "JSON 처리 중 오류가 발생했습니다."),
 
     // User
 
@@ -16,7 +17,7 @@ public enum ErrorCode {
     // Diary
     DIARY_NOT_FOUND(404, "D001", "일기를 찾을 수 없습니다."),
     INVALID_DIARY_ID(400, "D002", "일기 ID 형식이 잘못되었습니다."),
-    JSON_PROCESS_ERROR(500, "D003", "JSON 처리 중 오류가 발생했습니다."),
+
     SSE_ERROR(500, "D004", "SSE 처리 중 오류가 발생했습니다.");
 
     // Emotion

--- a/server/Spring/src/main/java/com/hanium/diarist/common/exception/GlobalExceptionHandler.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.hanium.diarist.domain.diary.exception.KafkaConnectException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -45,7 +46,12 @@ public class GlobalExceptionHandler {
     }
 
 
-
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<Object> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) { // JSON 형식이 잘못됐을 때 발생하는 예외
+        log.error("handleHttpMessageNotReadableException", e);
+        ErrorCode errorCode = ErrorCode.JSON_PROCESS_ERROR;
+        return handleExceptionInternal(errorCode);
+    }
 
 
     /// 에러 코드를 받아서 에러 메세지를 반환하는 함수

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/controller/DiaryController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/controller/DiaryController.java
@@ -1,20 +1,23 @@
 package com.hanium.diarist.domain.diary.controller;
 
+import com.hanium.diarist.common.response.ErrorResponse;
 import com.hanium.diarist.common.response.SuccessResponse;
-import com.hanium.diarist.domain.diary.dto.AdResponse;
-import com.hanium.diarist.domain.diary.dto.BookmarkDiaryRequest;
-import com.hanium.diarist.domain.diary.dto.BookmarkDiaryResponse;
-import com.hanium.diarist.domain.diary.dto.CreateDiaryRequest;
+import com.hanium.diarist.domain.diary.domain.Diary;
+import com.hanium.diarist.domain.diary.dto.*;
 import com.hanium.diarist.domain.diary.service.CreateDiaryConsumerService;
 import com.hanium.diarist.domain.diary.service.CreateDiaryProducerService;
 import com.hanium.diarist.domain.diary.service.DiaryService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.apache.catalina.connector.Response;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -23,7 +26,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.List;
-import java.util.concurrent.Executors;
 
 @RestController
 @RequestMapping("/api/v1/diary")
@@ -36,24 +38,28 @@ public class DiaryController {
     private final CreateDiaryConsumerService createDiaryConsumerService;
     private final DiaryService diaryService;
 
-    @PostMapping("/create")
-    @Operation(summary = "일기 생성 요청", description = "일기 생성 요청 API.")
+    @PostMapping("create/no_ad")
+    @Operation(summary = "일기 생성 요청, 광고 없음", description = "일기 생성 요청 API.")
     @ApiResponse(responseCode = "200", description = "일기 생성 요청 메세지큐에 등록 완료")
-    @ApiResponse(responseCode = "400", description = "잘못된 요청")
-    public ResponseEntity<String> createDiary(@Valid @RequestBody CreateDiaryRequest createDiaryRequest) {
+    public ResponseEntity<SuccessResponse<String>> createDiary(@Valid @RequestBody CreateDiaryRequest createDiaryRequest) {
         createDiaryProducerService.sendCreateDiaryMessage(createDiaryRequest);
-        return new ResponseEntity<>("일기 생성 요청 메세지큐에 등록 완료", HttpStatus.OK);
+        return SuccessResponse.of("일기 생성 요청 메세지큐에 등록 완료").asHttp(HttpStatus.CREATED);// 광고 시청 여부 반환
     }
 
-    @PostMapping
-    @Operation(summary = "광고 시청", description = "광고 시청 API.")
-    public SuccessResponse<AdResponse> createDiaryWithAd(@Valid @RequestBody CreateDiaryRequest createDiaryRequest) {
+    @PostMapping("create/ad")
+    @Operation(summary = "일기 생성 요청 및 광고 시청", description = "일기 생성 요청 및 광고 시청 API.")
+    @ApiResponse(responseCode = "200", description = "일기 생성 요청 메세지큐에 등록 완료")
+    public ResponseEntity<SuccessResponse<AdResponse>> createDiaryWithAd(@Valid @RequestBody CreateDiaryRequest createDiaryRequest) {
         boolean adRequired = createDiaryProducerService.sendCreateDiaryMessageWithAd(createDiaryRequest);
-        return SuccessResponse.of(new AdResponse(adRequired));// 광고 시청 여부 반환
+        return SuccessResponse.of(new AdResponse(adRequired)).asHttp(HttpStatus.CREATED);// 광고 시청 여부 반환
     }
+
+
 
 
     @GetMapping(value = "/kafka-response", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @Operation(summary = "일기 생성 요청 응답", description = "일기 생성 완료 요청을 클라이언트에 던져주는 API.")
+    @ApiResponse(responseCode = "200", description = "일기 생성 완료 요청을 클라이언트에 던져주는 API", content = @Content(array = @ArraySchema(schema = @Schema(implementation = CreateDiaryResponse.class))))
     public SseEmitter kafkaResponse() {
         // kafka consumer 가 emitter 에 데이터를 보내면 emitter 가 클라이언트에게 데이터를 보냄
         return createDiaryConsumerService.addEmitter();
@@ -61,6 +67,7 @@ public class DiaryController {
 
     @PostMapping("/bookmark")
     @Operation(summary = "일기 즐겨찾기 (1개)", description = "일기 즐겨찾기 API.")
+    @ApiResponse(responseCode = "200", description = "일기 즐겨찾기 성공")
     public ResponseEntity<SuccessResponse<BookmarkDiaryResponse>> bookmarkDiary(@RequestBody BookmarkDiaryRequest request) {
         BookmarkDiaryResponse response = diaryService.bookmarkDiary(request.getDiaryId(), request.isFavorite());
         return SuccessResponse.of(response).asHttp(HttpStatus.OK);
@@ -68,6 +75,7 @@ public class DiaryController {
 
     @PostMapping("/bookmark/delete")
     @Operation(summary = "일기 즐겨찾기 해제", description = "앨범페이지 일기 즐겨찾기 해제 API")
+    @ApiResponse(responseCode = "200",description = "일기 즐겨찾기 해제 성공")
     public ResponseEntity<SuccessResponse<List<BookmarkDiaryResponse>>> deleteBookmarkDiary(@RequestBody List<Long> diaryIdList) {
         List<BookmarkDiaryResponse> bookmarkDiaryResponses = diaryService.deleteBookmarkDiary(diaryIdList);
         return SuccessResponse.of(bookmarkDiaryResponses).asHttp(HttpStatus.OK);

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/CreateDiaryProducerService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/CreateDiaryProducerService.java
@@ -40,7 +40,7 @@ public class CreateDiaryProducerService {
             String message = objectMapper.writeValueAsString(createDiaryRequest);
             sendKafkaMessage(CreateTopicName,message);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("Failed to convert CreateDiaryRequest to JSON", e);
+            throw new JsonProcessException();
         }
     }
 

--- a/server/Spring/src/test/java/com/hanium/diarist/domain/diary/service/CreateDiaryProducerServiceTest.java
+++ b/server/Spring/src/test/java/com/hanium/diarist/domain/diary/service/CreateDiaryProducerServiceTest.java
@@ -1,94 +1,136 @@
-//package com.hanium.diarist.domain.diary.service;
-//
-//import com.fasterxml.jackson.databind.ObjectMapper;
-//import com.hanium.diarist.domain.diary.dto.CreateDiaryRequest;
-//import com.hanium.diarist.domain.diary.domain.Diary;
-//import com.hanium.diarist.domain.diary.repository.DiaryRepository;
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.Test;
-//import org.mockito.InjectMocks;
-//import org.mockito.Mock;
-//import org.mockito.MockitoAnnotations;
-//import org.springframework.kafka.core.KafkaTemplate;
-//
-//import java.time.LocalDate;
-//import java.util.Optional;
-//
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.Mockito.*;
-//
-//class CreateDiaryProducerServiceTest {
-//
-//    @Mock
-//    private KafkaTemplate<String, String> kafkaTemplate;
-//
-//    @Mock
-//    private ObjectMapper objectMapper;
-//
-//    @Mock
-//    private DiaryRepository diaryRepository;
-//
-//    @InjectMocks
-//    private CreateDiaryProducerService createDiaryProducerService;
-//
-//    @BeforeEach
-//    void setUp() {
-//        MockitoAnnotations.openMocks(this);
-//    }
-//
-//    @Test
-//    void testSendCreateDiaryMessage_FirstTimeToday() throws Exception {
-//        CreateDiaryRequest request = new CreateDiaryRequest();
-//        request.setDate(LocalDate.now());
-//
-//        when(diaryRepository.findByDate(any(LocalDate.class))).thenReturn(Optional.empty());
-//        when(objectMapper.writeValueAsString(any())).thenReturn("testMessage");
-//
-//        createDiaryProducerService.sendCreateDiaryMessage(request);
-//
-//        verify(kafkaTemplate, times(1)).send("create-diary", "testMessage");
-//        verify(kafkaTemplate, never()).send("reCreate-diary", "testMessage");
-//    }
-//
-//    @Test
-//    void testSendCreateDiaryMessage_RecreateToday() throws Exception {
-//        CreateDiaryRequest request = new CreateDiaryRequest();
-//        request.setDate(LocalDate.now());
-//
-//        when(diaryRepository.findByDate(any(LocalDate.class))).thenReturn(Optional.of(new Diary()));
-//        when(objectMapper.writeValueAsString(any())).thenReturn("testMessage");
-//
-//        createDiaryProducerService.sendCreateDiaryMessage(request);
-//
-//        verify(kafkaTemplate, times(1)).send("reCreate-diary", "testMessage");
-//        verify(kafkaTemplate, never()).send("create-diary", "testMessage");
-//    }
-//
-//    @Test
-//    void testSendCreateDiaryMessage_PastDate() throws Exception {
-//        CreateDiaryRequest request = new CreateDiaryRequest();
-//        request.setDate(LocalDate.now().minusDays(1));
-//
-//        when(diaryRepository.findByDate(any(LocalDate.class))).thenReturn(Optional.empty());
-//        when(objectMapper.writeValueAsString(any())).thenReturn("testMessage");
-//
-//        createDiaryProducerService.sendCreateDiaryMessage(request);
-//
-//        verify(kafkaTemplate, times(1)).send("create-diary", "testMessage");
-//        verify(kafkaTemplate, never()).send("reCreate-diary", "testMessage");
-//    }
-//
-//    @Test
-//    void testSendCreateDiaryMessage_RecreatePastDate() throws Exception {
-//        CreateDiaryRequest request = new CreateDiaryRequest();
-//        request.setDate(LocalDate.now().minusDays(1));
-//
-//        when(diaryRepository.findByDate(any(LocalDate.class))).thenReturn(Optional.of(new Diary()));
-//        when(objectMapper.writeValueAsString(any())).thenReturn("testMessage");
-//
-//        createDiaryProducerService.sendCreateDiaryMessage(request);
-//
-//        verify(kafkaTemplate, times(1)).send("reCreate-diary", "testMessage");
-//        verify(kafkaTemplate, never()).send("create-diary", "testMessage");
-//    }
-//}
+package com.hanium.diarist.domain.diary.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hanium.diarist.domain.diary.domain.Diary;
+import com.hanium.diarist.domain.diary.dto.CreateDiaryRequest;
+import com.hanium.diarist.domain.diary.exception.JsonProcessException;
+import com.hanium.diarist.domain.diary.repository.DiaryRepository;
+import com.hanium.diarist.domain.user.domain.SocialCode;
+import com.hanium.diarist.domain.user.domain.User;
+import com.hanium.diarist.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class CreateDiaryProducerServiceTest {
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private DiaryRepository diaryRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private CreateDiaryProducerService createDiaryProducerService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void sendCreateDiaryMessage_success() throws JsonProcessingException { // 일기 작성 메시지 전송 성공 여부 ( ad 없는 로직 )
+        CreateDiaryRequest request = CreateDiaryRequest.builder()
+                .userId(1L)
+                .emotionId(1L)
+                .artistId(1L)
+                .diaryDate(LocalDate.now())
+                .content("This is a test diary entry")
+                .build(); // 일기 작성 요청 생성
+        String message = "testMessage";// 전송 메세지
+
+        when(objectMapper.writeValueAsString(any())).thenReturn(message); // objectMapper.writeValueAsString(any()) 호출 시 message 반환 -> 로직에 있음.
+        CompletableFuture<SendResult<String, String>> future = // 완료된 상태의 객체
+                CompletableFuture.completedFuture(mock(SendResult.class)); // future 생성
+        when(kafkaTemplate.send(anyString(), anyString())).thenReturn(future); // kafkaTemplate.send(anyString(), anyString()) 호출 시 future 반환
+
+        assertDoesNotThrow(() -> createDiaryProducerService.sendCreateDiaryMessage(request)); // 예외를 던지지 않는다면 성공
+    }
+
+    @Test
+    void sendCreateDiaryMessage_jsonProcessingException() throws JsonProcessException, JsonProcessingException {
+        CreateDiaryRequest request = CreateDiaryRequest.builder()
+                .userId(1L)
+                .emotionId(1L)
+                .artistId(1L)
+                .diaryDate(LocalDate.now())
+                .content("This is a test diary entry")
+                .build();
+
+        when(objectMapper.writeValueAsString(any())).thenThrow(JsonProcessException.class); // jsonProcessException 발생하도록 설정
+
+        assertThrows(JsonProcessException.class, () -> createDiaryProducerService.sendCreateDiaryMessage(request)); // 예외 발생
+    }
+
+    @Test
+    void sendCreateDiaryMessageWithAd_noExistingDiaryAndToday() throws JsonProcessingException { // 오늘의 일기를 작성하는 로직 테스트
+        CreateDiaryRequest request = CreateDiaryRequest.builder()
+                .userId(1L)
+                .emotionId(1L)
+                .artistId(1L)
+                .diaryDate(LocalDate.now())
+                .content("This is a test diary entry")
+                .build();
+
+        User user = User.create("test@gmail.com", "test", SocialCode.KAKAO); // 임의의 유저
+        String message = "testMessage";
+
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user)); // userRepository.findById(anyLong()) 호출 시 테스트 user 반환
+        when(diaryRepository.findByUserAndDiaryDate(any(), any())).thenReturn(Optional.empty());// diaryRepository.findByUserAndDiaryDate(any(), any()) 호출 시 empty 반환
+        when(objectMapper.writeValueAsString(any())).thenReturn(message);// objectMapper.writeValueAsString(any()) 호출 시 message 반환
+        CompletableFuture<SendResult<String, String>> future = CompletableFuture.completedFuture(mock(SendResult.class));// future 생성
+        when(kafkaTemplate.send(anyString(), anyString())).thenReturn(future);// kafkaTemplate.send(anyString(), anyString()) 호출 시 future 반환
+
+        boolean result = createDiaryProducerService.sendCreateDiaryMessageWithAd(request);
+
+        assertFalse(result);
+        verify(kafkaTemplate).send(eq("create-diary"), eq(message)); // 토픽이 create-diary로 가는지 확인
+    }
+
+    @Test
+    void sendCreateDiaryMessageWithAd_existingDiaryOrPastDate() throws JsonProcessingException { // 재생성 토픽으로 가는지 확인
+        CreateDiaryRequest request = CreateDiaryRequest.builder()
+                .userId(1L)
+                .emotionId(1L)
+                .artistId(1L)
+                .diaryDate(LocalDate.now().minusDays(1))
+                .content("This is a test diary entry")
+                .build();
+
+        User user = User.create("test@gmail.com", "test", SocialCode.KAKAO);
+        Diary diary = new Diary(user, null, null, LocalDate.now(), "test", false, null);
+        String message = "testMessage";
+
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+        when(diaryRepository.findByUserAndDiaryDate(any(), any())).thenReturn(Optional.of(diary));
+        when(objectMapper.writeValueAsString(any())).thenReturn(message);
+        CompletableFuture<SendResult<String, String>> future = CompletableFuture.completedFuture(mock(SendResult.class));
+        when(kafkaTemplate.send(anyString(), anyString())).thenReturn(future);
+
+        boolean result = createDiaryProducerService.sendCreateDiaryMessageWithAd(request);
+
+        assertTrue(result);
+        verify(kafkaTemplate).send(eq("re-create-diary"), eq(message));
+    }
+
+
+}


### PR DESCRIPTION
## Jira 티켓


[PROJ-115](https://hanium.atlassian.net/browse/PROJ-115)

## 제목

일기 생성 요청을 kafka에 보내는 로직의 Test Code 작성

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- swagger 설명 부족
- Json 파싱이 불가할 경우 spring에서 기본적으로 제공하는 apiResponse를 통해 응답값 제공
-  카프카를 통해 메세지를 전달하는 로직의 test code 없음 

## 변경 후

- swagger의 추가적인 설명 추가 ( 응답값 확인 가능 ) 
<img width="1200" alt="image" src="https://github.com/hanium-4ward/Diarist/assets/110653633/713c8dd2-04d4-47f1-994c-f6defe8bbafb">
- json 파싱 불가할 경우의 response 예외처리 
<img width="1425" alt="image" src="https://github.com/hanium-4ward/Diarist/assets/110653633/d7966280-9038-4e29-a09b-b1c148761b9f">
- 카프카 test code 통과 결과물

![image](https://github.com/hanium-4ward/Diarist/assets/110653633/3d3e32d2-cea9-4d17-91fd-bab95ba20c25)



[PROJ-115]: https://hanium.atlassian.net/browse/PROJ-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ