### PR TITLE
feat : PROJ-116 : 즐겨찾기 로직 TestCode 작성

### DIFF
--- a/server/Spring/src/test/java/com/hanium/diarist/domain/diary/service/DiaryServiceTest.java
+++ b/server/Spring/src/test/java/com/hanium/diarist/domain/diary/service/DiaryServiceTest.java
@@ -1,0 +1,119 @@
+package com.hanium.diarist.domain.diary.service;
+
+import com.hanium.diarist.domain.artist.domain.Artist;
+import com.hanium.diarist.domain.artist.domain.Period;
+import com.hanium.diarist.domain.diary.domain.Diary;
+import com.hanium.diarist.domain.diary.dto.BookmarkDiaryResponse;
+import com.hanium.diarist.domain.diary.exception.DiaryNotFoundException;
+import com.hanium.diarist.domain.diary.repository.DiaryRepository;
+import com.hanium.diarist.domain.emotion.domain.Emotion;
+import com.hanium.diarist.domain.user.domain.SocialCode;
+import com.hanium.diarist.domain.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class DiaryServiceTest {
+    @InjectMocks
+    private DiaryService diaryService;
+
+    @Mock
+    private DiaryRepository diaryRepository;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+
+    @Test
+    void bookmarkDiary() {
+        //given
+        User user = User.create("a@gmail.com","test", SocialCode.KAKAO );
+        Artist artist = Artist.create("test1","test", Period.Contemporary, "test","test.png");
+        Emotion emotion = Emotion.create("test", "testPrompt", "test.png");
+
+        boolean favorite=true;
+        Diary testdiary = new Diary(user, emotion,artist, LocalDate.now(), "test", favorite,null);
+
+        //when
+        when(diaryRepository.findByDiaryId(1L)).thenReturn(Optional.of(testdiary));
+        when(diaryRepository.save(any(Diary.class))).thenReturn(testdiary);
+
+        BookmarkDiaryResponse response = diaryService.bookmarkDiary(1L, favorite);
+        //then
+        assertNotNull(response);
+        assertEquals(response.getDiaryId(), testdiary.getDiaryId());
+        assertTrue(response.isFavorite());
+
+        verify(diaryRepository).findByDiaryId(1L);
+        verify(diaryRepository, times(1)).save(testdiary);
+    }
+
+    @Test
+    void BookmarkDiary_DiaryNotFound(){
+        // given
+        User user = User.create("a@gmail.com","test", SocialCode.KAKAO );
+        Artist artist = Artist.create("test1","test", Period.Contemporary, "test","test.png");
+        Emotion emotion = Emotion.create("test", "testPrompt", "test.png");
+
+        boolean favorite=true;
+        Diary testdiary = new Diary(user, emotion,artist, LocalDate.now(), "test", favorite,null);
+        testdiary.setDiaryId(1L);
+
+        //when
+        when(diaryRepository.findByDiaryId(testdiary.getDiaryId())).thenReturn(Optional.empty()); // 없을 경우를 가정
+
+
+        //then
+        assertThrows(DiaryNotFoundException.class, () -> diaryService.bookmarkDiary(testdiary.getDiaryId(), favorite));
+
+        verify(diaryRepository, times(1)).findByDiaryId(testdiary.getDiaryId());
+        verify(diaryRepository, times(0)).save(any(Diary.class));
+    }
+
+    @Test
+    void deleteBookmarkDiary() {
+        List<Long> diaryIdList = Arrays.asList(1L, 2L, 3L);
+        User user = User.create("a@gmail.com","test", SocialCode.KAKAO );
+        Artist artist = Artist.create("test1","test", Period.Contemporary, "test","test.png");
+        Emotion emotion = Emotion.create("test", "testPrompt", "test.png");
+
+        boolean favorite=true;
+        Diary diary1 = new Diary(user, emotion,artist, LocalDate.now(), "test1", favorite,null);
+        Diary diary2 = new Diary(user, emotion,artist, LocalDate.now(), "test2", favorite,null);
+        Diary diary3 = new Diary(user, emotion,artist, LocalDate.now(), "test3", favorite,null);
+
+
+
+        List<Diary> diaries = Arrays.asList(diary1, diary2, diary3);
+
+        when(diaryRepository.findAllById(diaryIdList)).thenReturn(diaries);
+        when(diaryRepository.saveAll(anyList())).thenReturn(diaries);
+
+        List<BookmarkDiaryResponse> response = diaryService.deleteBookmarkDiary(diaryIdList);
+
+        assertNotNull(response);
+        assertEquals(3, response.size());// 해제한 갯수 3개
+        assertFalse(response.get(0).isFavorite());// 즐겨찾기 해제
+        assertFalse(response.get(1).isFavorite());// 즐겨찾기 해제
+        assertFalse(response.get(2).isFavorite());// 즐겨찾기 해제
+
+        verify(diaryRepository, times(1)).findAllById(diaryIdList);
+        verify(diaryRepository, times(1)).saveAll(diaries);
+    }
+
+
+
+}


### PR DESCRIPTION
## Jira 티켓

[PROJ-116](https://hanium.atlassian.net/browse/PROJ-116)

## 제목

즐겨찾기 로직 Test code 작성

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 즐겨찾기 로직에 대한 test code 미작성

## 변경 후

- 즐겨찾기 로직에 대한 test Code 작성
    - bookmarkDiary -> 즐겨찾기를 true로 하는 로직이 실행되었을때, true로 제대로 들어갔는지 확인. 
    - BookmarkDiary_DiaryNotFound  -> 즐겨찾기 로직에 없는 diaryId가 들어갔을 경우 DiaryNotFound 예외처리를 실행하는지 확인.
    - deleteBookmarkDiary -> 즐겨찾기 해제를 1,2,3번 diary에 대해서 했을때 해제된 일기가 3개인지, 1,2,3번의 일기의 즐겨찾기가 false로 되어있는지 확인.



[PROJ-116]: https://hanium.atlassian.net/browse/PROJ-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ