### PR TITLE
refactor : PROJ-118 : 이미지URL의 길이를 변경함

### DIFF
--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Image.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Image.java
@@ -21,7 +21,7 @@ public class Image extends BaseEntity {
     private Diary diary;
 
     @NotNull
-    @Column(nullable = false)
+    @Column(nullable = false,length = 500)
     private String imageUrl;
 
     // 프롬프트 일단 생략


### PR DESCRIPTION
## Jira 티켓

[PROJ-118](https://hanium.atlassian.net/browse/PROJ-118)

## 제목

이미지 URL 의 길이를 변경한다. 

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 이미지 url의 길이가 기본 세팅값 255자  이었음

## 변경 후

- 이미지 URL이 S3의 url이 담길 수 있게 500자로 늘림.


[PROJ-118]: https://hanium.atlassian.net/browse/PROJ-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ