### PR TITLE
feat : PROJ-87 : API 서버로 부터 받은 일기 데이터를 AI 모델에 전달한다.

### DIFF
--- a/model/Dockerfile
+++ b/model/Dockerfile
@@ -14,4 +14,4 @@ COPY .env /app/.env
 
 EXPOSE 8000
 
-CMD ["sh", "-c", "python manage.py runserver 0.0.0.0:8000"]
+CMD ["sh", "-c", "python manage.py runserver 0.0.0.0:8000 & python diary/consumer/create_diary_consumer.py & python diary/consumer/re_create_diary_consumer.py"]

--- a/model/diary/consumer/__init__.py
+++ b/model/diary/consumer/__init__.py
@@ -1,0 +1,1 @@
+from diary.consumer import create_diary_consumer, re_create_diary_consumer

--- a/model/diary/consumer/create_diary_consumer.py
+++ b/model/diary/consumer/create_diary_consumer.py
@@ -1,0 +1,106 @@
+import json
+import os
+import sys
+from datetime import datetime
+
+import django
+from confluent_kafka import Consumer, KafkaError
+from dotenv import load_dotenv
+from openai import OpenAI
+
+sys.path.append('/app/')
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+django.setup()
+
+from diary.models import Diary, User, Emotion, Image, Artist
+
+
+load_dotenv()
+
+KAFKA_BROKER_URL = os.getenv('KAFKA_BROKER_URL')
+CREATE_DIARY_TOPIC = os.getenv('KAFKA_TOPIC_CREATE')
+GROUP_ID = os.getenv('KAFKA_CREATE_GROUP')
+OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
+
+client = OpenAI(api_key=OPENAI_API_KEY)
+
+
+def generate_description(diary_text, artist_style, emotion):
+    query = f"{diary_text}라는 내용을 {artist_style}의 화풍으로 그려줘. 감정은 {emotion}이야."
+    response = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[
+            {"role": "system", "content": "Create an art diary entry response reflecting a specific artist's style without naming the artist."},
+            {"role": "system", "content": "Describe the scene you want to illustrate. Mention key characteristics of the style like impressionistic, vibrant colors, or soft lighting."},
+            {"role": "user", "content": query}
+        ],
+    )
+    return response.choices[0].message.content
+
+
+def generate_image(description):
+    response = client.images.generate(
+        model="dall-e-3",
+        prompt=description,
+        size="1024x1024",
+        quality="standard",
+        n=1
+    )
+    return response.data[0].url
+
+
+def process_message(message):
+    try:
+        data = json.loads(message.value().decode('utf-8'))
+        print(f"Received message: {data}")
+
+        user_id = data['user_id']
+        emotion_id = data['emotion_id']
+        artist_id = data['artist_id']
+        diary_date = datetime.strptime(data['diary_date'], '%Y-%m-%d')
+        content = data['content']
+
+        artist = Artist.objects.get(artist_id=artist_id)
+        emotion = Emotion.objects.get(emotion_id=emotion_id)
+
+        description = generate_description(content, artist.artist_name, emotion.emotion_name)
+        image_url = generate_image(description)
+
+        print(f"Generated image URL: {image_url}")
+    
+    except json.JSONDecodeError as e:
+        print(f"Error decoding JSON: {e}")
+        print(f"Failed message: {message.value()}")
+
+
+
+def consume():
+    consumer = Consumer({
+        'bootstrap.servers': KAFKA_BROKER_URL,
+        'group.id': GROUP_ID,
+        'auto.offset.reset': 'earliest'
+    })
+
+    consumer.subscribe([CREATE_DIARY_TOPIC])
+
+    while True:
+        msg = consumer.poll(1.0)
+
+        if msg is None:
+            continue
+
+        if msg.error():
+            if msg.error().code() == KafkaError._PARTITION_EOF:
+                continue
+            else:
+                print(msg.error())
+                break
+
+        process_message(msg)
+
+    consumer.close()
+
+
+if __name__ == "__main__":
+    consume()

--- a/model/diary/consumer/re_create_diary_consumer.py
+++ b/model/diary/consumer/re_create_diary_consumer.py
@@ -1,0 +1,105 @@
+import json
+import os
+import sys
+from datetime import datetime
+
+import django
+from confluent_kafka import Consumer, KafkaError
+from dotenv import load_dotenv
+from openai import OpenAI
+
+sys.path.append('/app/')
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
+django.setup()
+
+from diary.models import Diary, User, Emotion, Image, Artist
+
+
+load_dotenv()
+
+KAFKA_BROKER_URL = os.getenv('KAFKA_BROKER_URL')
+RE_CREATE_DIARY_TOPIC = os.getenv('KAFKA_TOPIC_RECREATE')
+GROUP_ID = os.getenv('KAFKA_RECREATE_GROUP')
+OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
+
+client = OpenAI(api_key=OPENAI_API_KEY)
+
+
+def generate_description(diary_text, artist_style, emotion):
+    query = f"{diary_text}라는 내용을 {artist_style}의 화풍으로 그려줘. 감정은 {emotion}이야."
+    response = client.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[
+            {"role": "system", "content": "Create an art diary entry response reflecting a specific artist's style without naming the artist."},
+            {"role": "system", "content": "Describe the scene you want to illustrate. Mention key characteristics of the style like impressionistic, vibrant colors, or soft lighting."},
+            {"role": "user", "content": query}
+        ],
+    )
+    return response.choices[0].message.content
+
+
+def generate_image(description):
+    response = client.images.generate(
+        model="dall-e-3",
+        prompt=description,
+        size="1024x1024",
+        quality="standard",
+        n=1
+    )
+    return response.data[0].url
+
+
+def process_message(message):
+    try:
+        data = json.loads(message.value().decode('utf-8'))
+        print(f"Received message: {data}")
+
+        user_id = data['user_id']
+        emotion_id = data['emotion_id']
+        artist_id = data['artist_id']
+        diary_date = datetime.strptime(data['diary_date'], '%Y-%m-%d')
+        content = data['content']
+
+        artist = Artist.objects.get(artist_id=artist_id)
+        emotion = Emotion.objects.get(emotion_id=emotion_id)
+
+        description = generate_description(content, artist.artist_name, emotion.emotion_name)
+        image_url = generate_image(description)
+
+        print(f"Generated image URL: {image_url}")
+    
+    except json.JSONDecodeError as e:
+        print(f"Error decoding JSON: {e}")
+        print(f"Failed message: {message.value()}")
+
+
+def consume():
+    consumer = Consumer({
+        'bootstrap.servers': KAFKA_BROKER_URL,
+        'group.id': GROUP_ID,
+        'auto.offset.reset': 'earliest'
+    })
+
+    consumer.subscribe([RE_CREATE_DIARY_TOPIC])
+
+    while True:
+        msg = consumer.poll(1.0)
+
+        if msg is None:
+            continue
+
+        if msg.error():
+            if msg.error().code() == KafkaError._PARTITION_EOF:
+                continue
+            else:
+                print(msg.error())
+                break
+
+        process_message(msg)
+
+    consumer.close()
+
+if __name__ == "__main__":
+    consume()
+

--- a/model/docker-compose.yml
+++ b/model/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3.8'
+
+services:
+  zookeeper:
+    image: wurstmeister/zookeeper:3.4.6
+    platform: linux/amd64
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: wurstmeister/kafka:2.12-2.5.0
+    platform: linux/amd64
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  django:
+    build: .
+    platform: linux/amd64
+    command: >
+      sh -c "
+      python manage.py runserver 0.0.0.0:8000 &
+      python diary/consumer/create_diary_consumer.py &
+      python diary/consumer/re_create_diary_consumer.py
+      "
+    environment:
+      - DEBUG=1
+      - DJANGO_DB_HOST=${POSTGRESQL_HOST}
+      - DJANGO_DB_NAME=${POSTGRESQL_NAME}
+      - DJANGO_DB_USER=${POSTGRESQL_USER}
+      - DJANGO_DB_PASSWORD=${POSTGRESQL_PWD}
+      - DJANGO_DB_PORT=${POSTGRESQL_PORT}
+      - KAFKA_BROKER_URL=${KAFKA_BROKER_URL}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    depends_on:
+      - kafka


### PR DESCRIPTION
## Jira 티켓

[PROJ-87](https://hanium.atlassian.net/jira/software/projects/PROJ/boards/1?assignee=712020%3Abcd40037-e3a8-4f14-ae52-22a15bb60035&selectedIssue=PROJ-87)

## 제목

API 서버로 부터 받은 일기 데이터를 AI 모델에 전달한다.

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [x] 기타: docker-compose 파일 생성 및 Dockerfile command 수정

## 변경 전

- 일기 데이터를 가져오는 코드가 구현되어있지 않았음.
- AI 서버 (Django)에서 kafka와 연결되어있지 않았음. 


## 변경 후

- API 서버에서 일기 데이터를 메세지 형태로 각 토픽 별로 넣어 둔 데이터를 해당 토픽에 맞게 차례로 꺼내와서 AI 모델에 전달해줌으로써 그림 이미지 생성하도록 함. 
 
<img width="400" alt="KakaoTalk_Photo_2024-06-18-22-39-38" src="https://github.com/hanium-4ward/Diarist/assets/105342203/345848b5-a548-4ada-ba39-e7ce2b8a2042">
<img width="400" alt="KakaoTalk_Photo_2024-06-18-22-37-17" src = "https://github.com/hanium-4ward/Diarist/assets/105342203/ee8eafae-753c-42d1-87ad-b9f1355ac204">

create-diary (일기 생성 요청) 토픽에 일기 데이터를 보냄(Producer - API 서버) -> AI 서버(Django)에서 차례로 가져와서 일기 데이터에 맞는 그림 이미지 url을 생성

</br>

<img width="400" alt="KakaoTalk_Photo_2024-06-18-22-41-44" src="https://github.com/hanium-4ward/Diarist/assets/105342203/a267d325-0a5d-4a76-a2db-38fff2187f6b">
<img width="400" alt="KakaoTalk_Photo_2024-06-18-22-42-06" src="https://github.com/hanium-4ward/Diarist/assets/105342203/601415e4-4dfb-4feb-a4c8-c9dc57c249ec">
re-create-diary (일기 재생성 요청) 토픽에 수정된 일기 데이터를 보냄 (Producer - API 서버) ->  Django에서 차례로 가져와서 일기 데이터에 맞는 그림 이미지 url을 재생성 (Consumer - AI 서버)





[PROJ-87]: https://hanium.atlassian.net/browse/PROJ-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ