### PR TITLE
feat : PROJ-117 : 일기 데이터가 저장완료되면 카프카로 일기 작성완료 메세지 보내기

### DIFF
--- a/model/diary/consumer/re_create_diary_consumer.py
+++ b/model/diary/consumer/re_create_diary_consumer.py
@@ -19,6 +19,7 @@ from diary.utils import S3ImgUploader
 
 KAFKA_BROKER_URL = settings.KAFKA_BROKER_URL
 RE_CREATE_DIARY_TOPIC = settings.KAFKA_TOPIC_RECREATE
+RESPONSE_DIARY_TOPIC = settings.KAFKA_TOPIC_RESPONSE
 GROUP_ID = settings.KAFKA_RECREATE_GROUP
 OPENAI_API_KEY = settings.OPENAI_API_KEY
 
@@ -47,6 +48,13 @@ def generate_image(description):
         n=1
     )
     return response.data[0].url
+
+
+def send_response(diary_id):
+    producer = Producer({'bootstrap.servers': KAFKA_BROKER_URL})
+    response_message = json.dumps({"diary_id": diary_id})
+    producer.produce(RESPONSE_DIARY_TOPIC, key=str(diary_id), value=response_message)
+    producer.flush()
 
 
 def process_message(message):
@@ -87,6 +95,8 @@ def process_message(message):
         diary.artist = artist
         diary.image = new_image
         diary.save()
+
+        send_response(diary.diary_id)
 
     except Diary.DoesNotExist:
         return f"Diary for user {user_id} on {diary_date} does not exist."


### PR DESCRIPTION
## Jira 티켓

[PROJ-117](https://hanium.atlassian.net/jira/software/projects/PROJ/boards/1?assignee=712020%3Abcd40037-e3a8-4f14-ae52-22a15bb60035&selectedIssue=PROJ-117)

## 제목

일기 데이터가 저장완료되면 카프카로 일기 작성완료 메세지 보내기

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 일기가 정상적으로 저장이 되고나서 다시 API 서버로 일기 작성완료 되었다고 알리는 로직이 없었음.

## 변경 후

- 일기가 정상적으로 저장이 되고나서 AI 서버에서 Kafka creat-diary-response 토픽으로 메세지를 보냄으로써 API 서버가 일기가 정상적으로 저장됨을 확인 할 수 있게 됨.
</br>

#### 예시 일기 데이터를 넣기
<img width="1128" alt="스크린샷 2024-06-19 오후 5 57 22" src="https://github.com/hanium-4ward/Diarist/assets/105342203/16101062-5718-4d7c-921e-6179a44b1a28">

#### RDB에 정상적으로 저장
<img width="793" alt="스크린샷 2024-06-19 오후 5 57 49" src="https://github.com/hanium-4ward/Diarist/assets/105342203/e6826279-2c89-4cdc-81bc-4d012bf48b61">


#### 일기 데이터가 저장되고 나서 자동으로 create-diary-response 토픽에 해당 방금 저장 된 일기 데이터 id값을 보냄
<img width="641" alt="스크린샷 2024-06-19 오후 5 59 04" src="https://github.com/hanium-4ward/Diarist/assets/105342203/e53d9f28-712f-486c-8ede-2e0422752da9">




[PROJ-117]: https://hanium.atlassian.net/browse/PROJ-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ