### PR TITLE
fix : PROJ-19 : 카카오 회원 가입시 구글 이메일과 중복될 경우 회원가입 오류 수정

### DIFF
--- a/server/Spring/src/main/java/com/hanium/diarist/domain/oauth/service/GoogleOauthService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/oauth/service/GoogleOauthService.java
@@ -46,7 +46,7 @@ public class GoogleOauthService {
         GoogleAccessToken token = getGoogleAccessToken(code);
         String socialRefreshToken = token.getRefreshToken();
         GoogleUserProfile userProfile = getUserProfile(token);
-        User user = validateUserService.validateRegisteredUserByEmail(userProfile.getEmail());
+        User user = validateUserService.validateRegisteredUserByEmail(userProfile.getEmail(),SocialCode.GOOGLE);
 
         if(user == null){ // 회원가입을 해야하는 경우
             user = userService.registerUser(userProfile.getEmail(), userProfile.getName(), SocialCode.GOOGLE);

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/oauth/service/KakaoOauthService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/oauth/service/KakaoOauthService.java
@@ -52,7 +52,7 @@ public class KakaoOauthService {
         KakaoUserProfile userProfile = getUserProfile(accessToken);
         Long userId = userProfile.getId();// 회원탈퇴시 사용될 userid
 
-        User user = validateUserService.validateRegisteredUserByEmail(userProfile.getKakao_account().getEmail());
+        User user = validateUserService.validateRegisteredUserByEmail(userProfile.getKakao_account().getEmail(),SocialCode.KAKAO);
 
         if(user == null){ // 회원가입을 해야하는 경우
             user = userService.registerUser(userProfile.getKakao_account().getEmail(), userProfile.getProperties().getNickname(), SocialCode.KAKAO);

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/user/repository/UserRepository.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.hanium.diarist.domain.user.repository;
 
+import com.hanium.diarist.domain.user.domain.SocialCode;
 import com.hanium.diarist.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,7 +11,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUserId(Long userId); // ID로 유저 찾기
 
-    List<User> findAllByEmail(String email);// Email로 유저 찾기
+    List<User> findAllByEmailAndSocialCode(String email, SocialCode socialCode);// Email로 유저 찾기
 
 
 }

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/user/service/ValidateUserService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/user/service/ValidateUserService.java
@@ -1,5 +1,6 @@
 package com.hanium.diarist.domain.user.service;
 
+import com.hanium.diarist.domain.user.domain.SocialCode;
 import com.hanium.diarist.domain.user.domain.User;
 import com.hanium.diarist.domain.user.exception.UserNotFoundException;
 import com.hanium.diarist.domain.user.repository.UserRepository;
@@ -13,8 +14,8 @@ import org.springframework.stereotype.Service;
 public class ValidateUserService {
     private final UserRepository userRepository;
 
-    public User validateRegisteredUserByEmail(String email) {
-        return userRepository.findAllByEmail(email).stream().findFirst().orElse(null);
+    public User validateRegisteredUserByEmail(String email, SocialCode socialCode){
+        return userRepository.findAllByEmailAndSocialCode(email,socialCode).stream().findFirst().orElse(null);
     }
 
     public User validateUserById(Long userId) {


### PR DESCRIPTION
## Jira 티켓

[PROJ-75](https://hanium.atlassian.net/browse/PROJ-75)

## 제목

제목을 작성하십시오.

## 작업유형

- [x] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 같은 이메일, 다른 소셜계정으로 회원가입 할 경우 회원가입 불가능.

## 변경 후

- 같은 이메일을 사용해도 회원가입하는 경로( 카카오, 구글 ) 이 다를 경우 회원가입이 가능하도록 수정

![image](https://github.com/hanium-4ward/Diarist/assets/110653633/33311270-851e-419f-959e-7b03a51f88cb)



[PROJ-75]: https://hanium.atlassian.net/browse/PROJ-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ