### PR TITLE
fix : PROJ-75 : 카카오,구글 승인코드 받는 uri, jwt 받는 uri 분리

### DIFF
--- a/server/Spring/src/main/java/com/hanium/diarist/domain/oauth/controller/OAuthController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/oauth/controller/OAuthController.java
@@ -17,7 +17,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -33,6 +32,18 @@ public class OAuthController {
     private final GoogleOauthService googleOauthService;
     private final OAuthService oAuthService;
     private final JwtTokenProvider jwtTokenProvider;
+
+    @Operation(summary = "카카오 승인코드", description = "카카오에서 Authorization code를 받아옵니다.")
+    @GetMapping("/kakao/login")
+    public ResponseEntity<SuccessResponse<Object>> kakaoCallback() {
+        return SuccessResponse.of(null).asHttp(HttpStatus.OK);
+    }
+
+    @Operation(summary = "구글 승인코드", description = "카카오에서 Authorization code를 받아옵니다.")
+    @GetMapping("/google/login")
+    public ResponseEntity<SuccessResponse<Object>> googleCallback() {
+        return SuccessResponse.of(null).asHttp(HttpStatus.OK);
+    }
 
 
     @Operation(summary = "카카오 로그인", description = "프론트로부터 Authorization code를 받아 카카오 로그인을 진행합니다.")
@@ -50,8 +61,8 @@ public class OAuthController {
                     responseCode = "500",
                     description = "O002 : 카카오 OAuth 서버와의 통신에 실패했습니다.",content = @Content(schema = @Schema(hidden = true)))
     })
-    @GetMapping("/kakao/login")
-    public ResponseEntity<SuccessResponse<ResponseJwtToken>> kakaoCallback(@RequestParam String code) {
+    @PostMapping("/kakao/login")
+    public ResponseEntity<SuccessResponse<ResponseJwtToken>> kakaoLogin(@RequestBody String code) {
 //        System.out.println(code);
         return SuccessResponse.of(kakaoOauthService.login(code)).asHttp(HttpStatus.OK);
     }
@@ -71,8 +82,8 @@ public class OAuthController {
                     responseCode = "500",
                     description = "O002 : 구글 OAuth 서버와의 통신에 실패했습니다.",content = @Content(schema = @Schema(hidden = true)))
     })
-    @GetMapping("/google/login")
-    public ResponseEntity<SuccessResponse<ResponseJwtToken>> googleCallback(@RequestParam String code) {
+    @PostMapping("/google/login")
+    public ResponseEntity<SuccessResponse<ResponseJwtToken>> googleCallback(@RequestBody String code) {
 //        System.out.println(googleOauthService.login(code));
         return SuccessResponse.of(googleOauthService.login(code)).asHttp(HttpStatus.OK);
     }

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/oauth/service/GoogleOauthService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/oauth/service/GoogleOauthService.java
@@ -46,7 +46,7 @@ public class GoogleOauthService {
         GoogleAccessToken token = getGoogleAccessToken(code);
         String socialRefreshToken = token.getRefreshToken();
         GoogleUserProfile userProfile = getUserProfile(token);
-        User user = validateUserService.validateRegisteredUserByEmail(userProfile.getEmail());
+        User user = validateUserService.validateRegisteredUserByEmail(userProfile.getEmail(),SocialCode.GOOGLE);
 
         if(user == null){ // 회원가입을 해야하는 경우
             user = userService.registerUser(userProfile.getEmail(), userProfile.getName(), SocialCode.GOOGLE);

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/oauth/service/KakaoOauthService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/oauth/service/KakaoOauthService.java
@@ -52,7 +52,7 @@ public class KakaoOauthService {
         KakaoUserProfile userProfile = getUserProfile(accessToken);
         Long userId = userProfile.getId();// 회원탈퇴시 사용될 userid
 
-        User user = validateUserService.validateRegisteredUserByEmail(userProfile.getKakao_account().getEmail());
+        User user = validateUserService.validateRegisteredUserByEmail(userProfile.getKakao_account().getEmail(),SocialCode.KAKAO);
 
         if(user == null){ // 회원가입을 해야하는 경우
             user = userService.registerUser(userProfile.getKakao_account().getEmail(), userProfile.getProperties().getNickname(), SocialCode.KAKAO);

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/user/repository/UserRepository.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.hanium.diarist.domain.user.repository;
 
+import com.hanium.diarist.domain.user.domain.SocialCode;
 import com.hanium.diarist.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,7 +11,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUserId(Long userId); // ID로 유저 찾기
 
-    List<User> findAllByEmail(String email);// Email로 유저 찾기
+    List<User> findAllByEmailAndSocialCode(String email, SocialCode socialCode);// Email로 유저 찾기
 
 
 }

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/user/service/ValidateUserService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/user/service/ValidateUserService.java
@@ -1,5 +1,6 @@
 package com.hanium.diarist.domain.user.service;
 
+import com.hanium.diarist.domain.user.domain.SocialCode;
 import com.hanium.diarist.domain.user.domain.User;
 import com.hanium.diarist.domain.user.exception.UserNotFoundException;
 import com.hanium.diarist.domain.user.repository.UserRepository;
@@ -13,8 +14,8 @@ import org.springframework.stereotype.Service;
 public class ValidateUserService {
     private final UserRepository userRepository;
 
-    public User validateRegisteredUserByEmail(String email) {
-        return userRepository.findAllByEmail(email).stream().findFirst().orElse(null);
+    public User validateRegisteredUserByEmail(String email, SocialCode socialCode){
+        return userRepository.findAllByEmailAndSocialCode(email,socialCode).stream().findFirst().orElse(null);
     }
 
     public User validateUserById(Long userId) {


### PR DESCRIPTION
## Jira 티켓

[PROJ-75](https://hanium.atlassian.net/browse/PROJ-75)
[PROJ-90](https://hanium.atlassian.net/browse/PROJ-90)

## 제목

제목을 작성하십시오.

## 작업유형

- [x] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 카카오의 승인코드를 받고 redirect uri에서 jwt 발급까지 모두 처리
- 해당 방법으로 진행할 시 프론트엔드에서 jwt를 받을 방법이 없음. 


## 변경 후

- 카카오 로그인시 redirect uri로 접근 후 승인코드를 uri에 띄움. 
- 프런트엔드에서 해당 승인코드를 통해 jwt를 가져오는 api를 post 호출
![image](https://github.com/hanium-4ward/Diarist/assets/110653633/e87be55e-89d0-4a92-9efb-ad6afa50a5e8)
body에 승인코드를 담아 전송하면 됨. 
![image](https://github.com/hanium-4ward/Diarist/assets/110653633/090cdfec-9fb5-483d-bf24-7d880cae53a4)




[PROJ-75]: https://hanium.atlassian.net/browse/PROJ-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROJ-90]: https://hanium.atlassian.net/browse/PROJ-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ