### PR TITLE
fix : PROJ-19 : jwt를 받을 때 dto를 통해 받도록 재설정

### DIFF
--- a/server/Spring/src/main/java/com/hanium/diarist/domain/oauth/controller/OAuthController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/oauth/controller/OAuthController.java
@@ -8,6 +8,7 @@ import com.hanium.diarist.common.security.jwt.JwtType;
 import com.hanium.diarist.common.security.jwt.exception.ExpiredAccessTokenException;
 import com.hanium.diarist.common.security.jwt.exception.InvalidTokenException;
 import com.hanium.diarist.common.utils.HeaderUtils;
+import com.hanium.diarist.domain.oauth.dto.AuthorizationCode;
 import com.hanium.diarist.domain.oauth.dto.ResponseJwtToken;
 import com.hanium.diarist.domain.oauth.service.GoogleOauthService;
 import com.hanium.diarist.domain.oauth.service.KakaoOauthService;
@@ -39,7 +40,7 @@ public class OAuthController {
         return SuccessResponse.of(null).asHttp(HttpStatus.OK);
     }
 
-    @Operation(summary = "구글 승인코드", description = "카카오에서 Authorization code를 받아옵니다.")
+    @Operation(summary = "구글 승인코드", description = "구글에서 Authorization code를 받아옵니다.")
     @GetMapping("/google/login")
     public ResponseEntity<SuccessResponse<Object>> googleCallback() {
         return SuccessResponse.of(null).asHttp(HttpStatus.OK);
@@ -62,8 +63,9 @@ public class OAuthController {
                     description = "O002 : 카카오 OAuth 서버와의 통신에 실패했습니다.",content = @Content(schema = @Schema(hidden = true)))
     })
     @PostMapping("/kakao/login")
-    public ResponseEntity<SuccessResponse<ResponseJwtToken>> kakaoLogin(@RequestBody String code) {
+    public ResponseEntity<SuccessResponse<ResponseJwtToken>> kakaoLogin(@RequestBody AuthorizationCode authorizationCode) {
 //        System.out.println(code);
+        String code = authorizationCode.getCode();
         return SuccessResponse.of(kakaoOauthService.login(code)).asHttp(HttpStatus.OK);
     }
 
@@ -83,8 +85,8 @@ public class OAuthController {
                     description = "O002 : 구글 OAuth 서버와의 통신에 실패했습니다.",content = @Content(schema = @Schema(hidden = true)))
     })
     @PostMapping("/google/login")
-    public ResponseEntity<SuccessResponse<ResponseJwtToken>> googleCallback(@RequestBody String code) {
-//        System.out.println(googleOauthService.login(code));
+    public ResponseEntity<SuccessResponse<ResponseJwtToken>> googleCallback(@RequestBody AuthorizationCode authorizationCode) {
+        String code = authorizationCode.getCode();
         return SuccessResponse.of(googleOauthService.login(code)).asHttp(HttpStatus.OK);
     }
 

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/oauth/dto/AuthorizationCode.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/oauth/dto/AuthorizationCode.java
@@ -1,0 +1,15 @@
+package com.hanium.diarist.domain.oauth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthorizationCode {
+
+    private String code;
+
+
+}


### PR DESCRIPTION
## Jira 티켓

[PROJ-19](https://hanium.atlassian.net/browse/PROJ-19)

## 제목

fix : PROJ-19 : jwt를 받을 때 dto를 통해 받도록 재설정 

## 작업유형

- [x] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 그냥 string code로 받도록 설정

## 변경 후

- dto로 받도록 설정. 
- json형식으로 {"code":"aaaaaa"} 형식으로 body에 담아 전송하도록 변경


[PROJ-19]: https://hanium.atlassian.net/browse/PROJ-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ