### PR TITLE
feat : PROJ-22 : 일기 상세 페이지 api 구현

### DIFF
--- a/server/Spring/build.gradle
+++ b/server/Spring/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 
     // kafka
     implementation 'org.springframework.kafka:spring-kafka'
+    //aws
+    implementation 'software.amazon.awssdk:s3:2.17.89'
+
 
 
     implementation 'com.fasterxml.jackson.core:jackson-databind'// jackson 라이브러리 추가 ( json 파싱 )

--- a/server/Spring/src/main/java/com/hanium/diarist/DiaristApplication.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/DiaristApplication.java
@@ -28,6 +28,11 @@ public class DiaristApplication {
         System.setProperty("GOOGLE_CLIENT_ID", dotenv.get("GOOGLE_CLIENT_ID"));
         System.setProperty("GOOGLE_CLIENT_SECRET", dotenv.get("GOOGLE_CLIENT_SECRET"));
         System.setProperty("GOOGLE_REDIRECT_URI", dotenv.get("GOOGLE_REDIRECT_URI"));
+        System.setProperty("AWS_SECRET_ACCESS_KEY", dotenv.get("AWS_SECRET_ACCESS_KEY"));
+        System.setProperty("AWS_ACCESS_KEY_ID", dotenv.get("AWS_ACCESS_KEY_ID"));
+        System.setProperty("AWS_S3_BUCKET", dotenv.get("AWS_S3_BUCKET"));
+        System.setProperty("AWS_ENDPOINT", dotenv.get("AWS_ENDPOINT"));
+
 
 
 

--- a/server/Spring/src/main/java/com/hanium/diarist/common/config/AwsS3Config.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/config/AwsS3Config.java
@@ -1,0 +1,29 @@
+package com.hanium.diarist.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AwsS3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                .build();
+    }
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/controller/DiaryController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/controller/DiaryController.java
@@ -1,20 +1,15 @@
 package com.hanium.diarist.domain.diary.controller;
 
-import com.hanium.diarist.common.response.ErrorResponse;
 import com.hanium.diarist.common.response.SuccessResponse;
-import com.hanium.diarist.domain.diary.domain.Diary;
 import com.hanium.diarist.domain.diary.dto.*;
 import com.hanium.diarist.domain.diary.service.CreateDiaryConsumerService;
 import com.hanium.diarist.domain.diary.service.CreateDiaryProducerService;
 import com.hanium.diarist.domain.diary.service.DiaryService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -79,6 +74,14 @@ public class DiaryController {
     public ResponseEntity<SuccessResponse<List<BookmarkDiaryResponse>>> deleteBookmarkDiary(@RequestBody List<Long> diaryIdList) {
         List<BookmarkDiaryResponse> bookmarkDiaryResponses = diaryService.deleteBookmarkDiary(diaryIdList);
         return SuccessResponse.of(bookmarkDiaryResponses).asHttp(HttpStatus.OK);
+    }
+
+    @GetMapping("/detail/{diaryId}")
+    @Operation(summary = "일기 상세 조회", description = "일기 상세 조회 API.")
+    @ApiResponse(responseCode = "200", description = "일기 상세 조회 성공")
+    public ResponseEntity<SuccessResponse<DiaryDetailResponse>> getDiaryDetail(@PathVariable Long diaryId) {
+        DiaryDetailResponse diaryDetailResponse = diaryService.getDiaryDetail(diaryId);
+        return SuccessResponse.of(diaryDetailResponse).asHttp(HttpStatus.OK);
     }
 
 

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/controller/DiaryController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/controller/DiaryController.java
@@ -1,6 +1,8 @@
 package com.hanium.diarist.domain.diary.controller;
 
+import com.hanium.diarist.common.resolver.AuthUser;
 import com.hanium.diarist.common.response.SuccessResponse;
+import com.hanium.diarist.common.security.jwt.JwtTokenInfo;
 import com.hanium.diarist.domain.diary.dto.*;
 import com.hanium.diarist.domain.diary.service.CreateDiaryConsumerService;
 import com.hanium.diarist.domain.diary.service.CreateDiaryProducerService;
@@ -82,6 +84,15 @@ public class DiaryController {
     public ResponseEntity<SuccessResponse<DiaryDetailResponse>> getDiaryDetail(@PathVariable Long diaryId) {
         DiaryDetailResponse diaryDetailResponse = diaryService.getDiaryDetail(diaryId);
         return SuccessResponse.of(diaryDetailResponse).asHttp(HttpStatus.OK);
+    }
+
+    @DeleteMapping("/detail/{diaryId}")
+    @Operation(summary = "일기 삭제", description = "일기 삭제 API.")
+    @ApiResponse(responseCode = "204", description = "일기 삭제 성공")
+    public ResponseEntity<SuccessResponse<String>> deleteDiary(@PathVariable Long diaryId, @AuthUser JwtTokenInfo jwtTokenInfo) {
+        Long userId = jwtTokenInfo.getUserId();
+        diaryService.deleteDiary(diaryId,userId);
+        return SuccessResponse.of("일기 삭제 성공").asHttp(HttpStatus.NO_CONTENT);
     }
 
 

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Diary.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Diary.java
@@ -90,4 +90,8 @@ public class Diary extends BaseEntityWithUpdate {
     public void setImage(Image image) {
         this.image = image;
     }
+
+    public void deleteDiary() {
+        this.deletedAt = LocalDateTime.now();
+    }// 일기 삭제
 }

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Image.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Image.java
@@ -27,7 +27,8 @@ public class Image extends BaseEntity {
     // 프롬프트 일단 생략
 
 
-
-
-
+    public Image(Diary diary, String imageUrl) {
+        this.diary = diary;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Image.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/domain/Image.java
@@ -6,10 +6,12 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "image_url != 'deleted'") // image_url 이 "deleted" 아닌 것만 조회
 public class Image extends BaseEntity {
 
     @Id
@@ -30,5 +32,9 @@ public class Image extends BaseEntity {
     public Image(Diary diary, String imageUrl) {
         this.diary = diary;
         this.imageUrl = imageUrl;
+    }
+
+    public void deleteImage(){
+        this.imageUrl = "deleted";
     }
 }

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/DiaryDetailResponse.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/DiaryDetailResponse.java
@@ -1,0 +1,44 @@
+package com.hanium.diarist.domain.diary.dto;
+
+import com.hanium.diarist.domain.artist.domain.Artist;
+import com.hanium.diarist.domain.diary.domain.Diary;
+import com.hanium.diarist.domain.emotion.domain.Emotion;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DiaryDetailResponse {
+    private final String diaryDate;
+    private final boolean favorite;
+    private final String imageUrl;
+    private final String emotionName;
+    private final String emotionPicture;
+    private final String artistName;
+    private final String artistPicture;
+    private final String content;
+
+
+    @Builder(access = AccessLevel.PRIVATE)
+    public DiaryDetailResponse(Diary diary,Artist artist,Emotion emotion) {
+        this.diaryDate = diary.getDiaryDate().toString();
+        this.favorite = diary.isFavorite();
+        this.imageUrl = diary.getImage().getImageUrl();
+        this.content = diary.getContent();
+        this.emotionName = emotion.getEmotionName();
+        this.emotionPicture = emotion.getEmotionPicture();
+        this.artistName = artist.getArtistName();
+        this.artistPicture = artist.getArtistPicture();
+    }
+
+    public static DiaryDetailResponse of(Diary diary, Emotion emotion, Artist artist) {
+        return DiaryDetailResponse.builder()
+                .diary(diary)
+                .artist(artist)
+                .emotion(emotion)
+                .build();
+    }
+
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/DiaryService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/DiaryService.java
@@ -2,6 +2,7 @@ package com.hanium.diarist.domain.diary.service;
 
 import com.hanium.diarist.domain.diary.domain.Diary;
 import com.hanium.diarist.domain.diary.dto.BookmarkDiaryResponse;
+import com.hanium.diarist.domain.diary.dto.DiaryDetailResponse;
 import com.hanium.diarist.domain.diary.exception.DiaryNotFoundException;
 import com.hanium.diarist.domain.diary.repository.DiaryRepository;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +41,14 @@ public class DiaryService {
     }
 
 
+    public DiaryDetailResponse getDiaryDetail(Long diaryId) {
+        Optional<Diary> diary = diaryRepository.findByDiaryIdWithDetails(diaryId);
+        if(diary.isEmpty()){
+            throw new DiaryNotFoundException();
+        }
+        Diary diaryObject = diary.get(); // optional 객체를 diary 객체로 변환
+        return DiaryDetailResponse.of(diaryObject,diaryObject.getEmotion(),diaryObject.getArtist());
+    }
 }
 
 

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/DiaryService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/DiaryService.java
@@ -1,13 +1,18 @@
 package com.hanium.diarist.domain.diary.service;
 
 import com.hanium.diarist.domain.diary.domain.Diary;
+import com.hanium.diarist.domain.diary.domain.Image;
 import com.hanium.diarist.domain.diary.dto.BookmarkDiaryResponse;
 import com.hanium.diarist.domain.diary.dto.DiaryDetailResponse;
 import com.hanium.diarist.domain.diary.exception.DiaryNotFoundException;
 import com.hanium.diarist.domain.diary.repository.DiaryRepository;
+import com.hanium.diarist.domain.user.service.ValidateUserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,11 +22,18 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class DiaryService {
     private final DiaryRepository diaryRepository;
+    private final ValidateUserService validateUserService;
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+
 
     @Transactional
     public BookmarkDiaryResponse bookmarkDiary(Long diaryId, boolean favorite) {
         Optional<Diary> diary = diaryRepository.findByDiaryId(diaryId);
-        if(!diary.isPresent()){
+        if(diary.isEmpty()){
             throw new DiaryNotFoundException();
         }
         Diary updateDiary = diary.get();
@@ -49,6 +61,34 @@ public class DiaryService {
         Diary diaryObject = diary.get(); // optional 객체를 diary 객체로 변환
         return DiaryDetailResponse.of(diaryObject,diaryObject.getEmotion(),diaryObject.getArtist());
     }
+
+    @Transactional
+    public void deleteDiary(Long diaryId,Long userId) {
+        validateUserService.validateUserById(userId);
+        Optional<Diary> diaryOptional = diaryRepository.findByDiaryId(diaryId);
+        if(diaryOptional.isEmpty()){
+            throw new DiaryNotFoundException();
+        }
+        Diary diary = diaryOptional.get();
+        Image image = diary.getImage();
+        String imageUrl = diary.getImage().getImageUrl();
+        imageUrl = imageUrl.substring(imageUrl.lastIndexOf("/")+1);
+        image.deleteImage();
+
+        deleteFileFromS3(bucket,imageUrl);
+        diary.deleteDiary();
+    }
+
+    private void deleteFileFromS3(String bucketName, String fileKey) {
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileKey)
+                .build();
+        s3Client.deleteObject(deleteObjectRequest);
+    }
+
+
+
 }
 
 

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/DiaryService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/DiaryService.java
@@ -72,7 +72,7 @@ public class DiaryService {
         Diary diary = diaryOptional.get();
         Image image = diary.getImage();
         String imageUrl = diary.getImage().getImageUrl();
-        imageUrl = imageUrl.substring(imageUrl.lastIndexOf("/")+1);
+        imageUrl = imageUrl.substring(imageUrl.indexOf("/", imageUrl.indexOf("//") + 2) + 1);
         image.deleteImage();
 
         deleteFileFromS3(bucket,imageUrl);

--- a/server/Spring/src/main/resources/application-aws.yml
+++ b/server/Spring/src/main/resources/application-aws.yml
@@ -1,0 +1,12 @@
+cloud:
+  aws:
+    credentials:
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
+      access-key: ${AWS_ACCESS_KEY_ID}
+    s3:
+      bucket: ${AWS_S3_BUCKET}
+      endpoint: ${AWS_S3_ENDPOINT}
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false

--- a/server/Spring/src/main/resources/application.yml
+++ b/server/Spring/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   profiles:
     active: dev
-    include: kafka, oauth
+    include: kafka,oauth,aws
   datasource:
     url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/default
     username: ${DB_USERNAME}

--- a/server/Spring/src/test/java/com/hanium/diarist/domain/diary/service/DiaryServiceTest.java
+++ b/server/Spring/src/test/java/com/hanium/diarist/domain/diary/service/DiaryServiceTest.java
@@ -3,7 +3,9 @@ package com.hanium.diarist.domain.diary.service;
 import com.hanium.diarist.domain.artist.domain.Artist;
 import com.hanium.diarist.domain.artist.domain.Period;
 import com.hanium.diarist.domain.diary.domain.Diary;
+import com.hanium.diarist.domain.diary.domain.Image;
 import com.hanium.diarist.domain.diary.dto.BookmarkDiaryResponse;
+import com.hanium.diarist.domain.diary.dto.DiaryDetailResponse;
 import com.hanium.diarist.domain.diary.exception.DiaryNotFoundException;
 import com.hanium.diarist.domain.diary.repository.DiaryRepository;
 import com.hanium.diarist.domain.emotion.domain.Emotion;
@@ -41,7 +43,7 @@ class DiaryServiceTest {
     void bookmarkDiary() {
         //given
         User user = User.create("a@gmail.com","test", SocialCode.KAKAO );
-        Artist artist = Artist.create("test1","test", Period.Contemporary, "test","test.png");
+        Artist artist = Artist.create("test1","test", Period.Contemporary, "test","test.png","example.png");
         Emotion emotion = Emotion.create("test", "testPrompt", "test.png");
 
         boolean favorite=true;
@@ -65,7 +67,7 @@ class DiaryServiceTest {
     void BookmarkDiary_DiaryNotFound(){
         // given
         User user = User.create("a@gmail.com","test", SocialCode.KAKAO );
-        Artist artist = Artist.create("test1","test", Period.Contemporary, "test","test.png");
+        Artist artist = Artist.create("test1","test", Period.Contemporary, "test","test.png","example.png");
         Emotion emotion = Emotion.create("test", "testPrompt", "test.png");
 
         boolean favorite=true;
@@ -87,7 +89,7 @@ class DiaryServiceTest {
     void deleteBookmarkDiary() {
         List<Long> diaryIdList = Arrays.asList(1L, 2L, 3L);
         User user = User.create("a@gmail.com","test", SocialCode.KAKAO );
-        Artist artist = Artist.create("test1","test", Period.Contemporary, "test","test.png");
+        Artist artist = Artist.create("test1","test", Period.Contemporary, "test","test.png","example.png");
         Emotion emotion = Emotion.create("test", "testPrompt", "test.png");
 
         boolean favorite=true;
@@ -113,6 +115,42 @@ class DiaryServiceTest {
         verify(diaryRepository, times(1)).findAllById(diaryIdList);
         verify(diaryRepository, times(1)).saveAll(diaries);
     }
+
+    @Test
+    void getDiaryDetailExistingDiary(){
+        //given
+        long diaryId = 1L;
+        User user = User.create("a@gmail.com","test", SocialCode.KAKAO );
+        Artist artist = Artist.create("test1","test", Period.Contemporary, "test","test.png","example.png");
+        Emotion emotion = Emotion.create("test", "testPrompt", "test.png");
+
+
+        boolean favorite=true;
+        Diary mockDiary = new Diary(user, emotion,artist, LocalDate.now(), "test1", favorite,null);
+
+        Image image = new Image(mockDiary,"test.png");
+        mockDiary.setImage(image);
+
+        // when
+        when(diaryRepository.findByDiaryIdWithDetails(diaryId)).thenReturn(Optional.of(mockDiary));
+
+        DiaryDetailResponse diaryDetail = diaryService.getDiaryDetail(diaryId);
+
+        // then
+        assertNotNull(diaryDetail);
+        assertEquals(mockDiary.getDiaryDate().toString(), diaryDetail.getDiaryDate());
+        assertEquals(mockDiary.isFavorite(), diaryDetail.isFavorite());
+        assertEquals(mockDiary.getContent(), diaryDetail.getContent());
+        assertEquals(mockDiary.getEmotion().getEmotionName(), diaryDetail.getEmotionName());
+        assertEquals(mockDiary.getEmotion().getEmotionPicture(), diaryDetail.getEmotionPicture());
+        assertEquals(mockDiary.getArtist().getArtistName(), diaryDetail.getArtistName());
+        assertEquals(mockDiary.getArtist().getArtistPicture(), diaryDetail.getArtistPicture());
+
+        verify(diaryRepository, times(1)).findByDiaryIdWithDetails(diaryId);
+
+
+    }
+
 
 
 


### PR DESCRIPTION
## Jira 티켓

* 유저스토리
    [PROJ-22](https://hanium.atlassian.net/browse/PROJ-22)

* 하위태스크
    [PROJ-73](https://hanium.atlassian.net/browse/PROJ-73)
    [PROJ-74](https://hanium.atlassian.net/browse/PROJ-74)

## 제목

일기 상세 페이지 구현 ( 일기 상세페이지 데이터 제공, 일기 삭제 로직 구현)

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [x] 기타: test 코드

## 변경 전

- 일기 상세 페이지 데이터 미 제공
- 일기 삭제 불가

## 변경 후
- 일기 상세 페이지 데이터  (다음과 같이 제공)

![image](https://github.com/hanium-4ward/Diarist/assets/110653633/30c06ea6-119c-4d95-afb0-bd5cfaca0626)


- 일기 삭제시 S3에 있는 이미지 같이 삭제
- 일기 삭제시 diary의 deletedAt이 삭제 시간으로 변경됨 ( soft delete)
- 일기 삭제시 이미지 삭제로 인해 imageurl 이 deleted로 변경됨




[PROJ-22]: https://hanium.atlassian.net/browse/PROJ-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROJ-73]: https://hanium.atlassian.net/browse/PROJ-73?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROJ-74]: https://hanium.atlassian.net/browse/PROJ-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ