### PR TITLE
feat : PROJ-30 : 일기 재생성 요청 시 S3에 저장되어있던 기존 이미지 URL도 삭제되도록 로직 재구현

### DIFF
--- a/model/diary/consumer/re_create_diary_consumer.py
+++ b/model/diary/consumer/re_create_diary_consumer.py
@@ -85,7 +85,10 @@ def process_message(message):
 
         diary = Diary.objects.get(user=user, diary_date=diary_date)
 
+        old_image_url = diary.image.image_url
         old_image = diary.image
+
+        S3ImgUploader.delete_image(old_image_url)
         old_image.delete()
 
         new_image = Image.objects.create(image_url=s3_url)

--- a/model/diary/utils.py
+++ b/model/diary/utils.py
@@ -55,3 +55,22 @@ class S3ImgUploader:
         except Exception as e:
             print(f"Failed to upload image to S3: {e}")
             return None
+
+    @staticmethod
+    def delete_image(image_url):
+        try:
+            s3_client = boto3.client(
+                "s3",
+                aws_access_key_id=AWS_ACCESS_KEY_ID,
+                aws_secret_access_key=AWS_SECRET_ACCESS_KEY
+            )
+            bucket_name = AWS_S3_BUCKET_NAME
+            key = image_url.replace(AWS_S3_ENDPOINT_URL, "")
+
+            s3_client.delete_object(Bucket=bucket_name, Key=key)
+            print(f"Deleted image from S3: {image_url}")
+        
+        except NoCredentialsError:
+            print("Credentials not available")
+        except Exception as e:
+            print(f"Failed to delete image from S3: {e}")


### PR DESCRIPTION
## Jira 티켓

유저스토리
[PROJ-30](https://hanium.atlassian.net/browse/PROJ-30) </br>
하위태스크
[PROJ-110](https://hanium.atlassian.net/browse/PROJ-110)

## 제목

일기 재생성 요청 시 S3에 저장되어있던 기존 이미지 URL도 삭제되도록 로직 재구현

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 일기 재생성 요청 시 기존 일기데이터에 저장되어있던 이미지가 RDS Image, Diary에서는 정상적으로 삭제되지만 S3에서는 기존 이미지가 삭제되는 로직이 구현되어있지않았음. 

## 변경 후

- 일기 재생성 요청 시 S3에서도 기존 일기데이터에 해당하는 이미지 URL은 삭제하고 재생성 된 S3 이미지 URL만 보관되도록 구현.


[PROJ-30]: https://hanium.atlassian.net/browse/PROJ-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROJ-110]: https://hanium.atlassian.net/browse/PROJ-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ