### PR TITLE
feat : PROJ-20 : 캘린더 페이지에 사용될 api 개발

### DIFF
--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/controller/DiaryController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/controller/DiaryController.java
@@ -35,6 +35,7 @@ public class DiaryController {
     private final CreateDiaryConsumerService createDiaryConsumerService;
     private final DiaryService diaryService;
 
+    @Deprecated
     @PostMapping("create/no_ad")
     @Operation(summary = "일기 생성 요청, 광고 없음", description = "일기 생성 요청 API.")
     @ApiResponse(responseCode = "200", description = "일기 생성 요청 메세지큐에 등록 완료")
@@ -100,6 +101,14 @@ public class DiaryController {
     @ApiResponse(responseCode = "200", description = "일기 앨범 리스트 가져오기")
     public ResponseEntity<SuccessResponse<List<AlbumResponse>>> AlbumList(@AuthUser JwtTokenInfo jwtTokenInfo) {
         List<AlbumResponse> response = diaryService.getBookmarkList(jwtTokenInfo.getUserId());
+        return SuccessResponse.of(response).asHttp(HttpStatus.OK);
+    }
+
+    @GetMapping("/list")
+    @Operation(summary = "캘린더 리스트", description = "캘린더 페이지에 사용될 API")
+    @ApiResponse(responseCode = "200", description = "캘린더 리스트 가져오기")
+    public ResponseEntity<SuccessResponse<List<DiaryListResponse>>> getCalendarList(@AuthUser JwtTokenInfo jwtTokenInfo) {
+        List<DiaryListResponse> response = diaryService.getDiaryList(jwtTokenInfo.getUserId());
         return SuccessResponse.of(response).asHttp(HttpStatus.OK);
     }
 

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/DiaryListResponse.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/DiaryListResponse.java
@@ -1,0 +1,14 @@
+package com.hanium.diarist.domain.diary.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DiaryListResponse {
+    private final Long diaryId;
+    private final String date;
+    private final String imageUrl;
+
+
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/repository/DiaryRepository.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/repository/DiaryRepository.java
@@ -14,6 +14,9 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
     Optional<Diary> findByUserAndDiaryDate(User user, LocalDate diaryDate);
     Optional<Diary> findByDiaryId(long diaryId);
 
+    @Query("select d from Diary d join fetch d.image where d.user = :user")
+    List<Diary> findAllByUser(User user);
+
     @Query("select d from Diary d join fetch d.emotion join fetch d.artist join fetch d.image where d.diaryId = :diaryId")
     Optional<Diary> findByDiaryIdWithDetails(long diaryId);
 

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/DiaryService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/DiaryService.java
@@ -5,9 +5,11 @@ import com.hanium.diarist.domain.diary.domain.Image;
 import com.hanium.diarist.domain.diary.dto.AlbumResponse;
 import com.hanium.diarist.domain.diary.dto.BookmarkDiaryResponse;
 import com.hanium.diarist.domain.diary.dto.DiaryDetailResponse;
+import com.hanium.diarist.domain.diary.dto.DiaryListResponse;
 import com.hanium.diarist.domain.diary.exception.DiaryNotFoundException;
 import com.hanium.diarist.domain.diary.repository.DiaryRepository;
 import com.hanium.diarist.domain.diary.repository.ImageRepository;
+import com.hanium.diarist.domain.user.domain.User;
 import com.hanium.diarist.domain.user.service.ValidateUserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -97,6 +99,14 @@ public class DiaryService {
         List<Diary> diaries = diaryRepository.findByUserIdAndFavorite(userId, true);
         return diaries.stream()
                 .map(diary -> new AlbumResponse(diary.getDiaryId(), diary.getDiaryDate().toString(), diary.getContent(), diary.getEmotion().getEmotionName(), diary.getArtist().getArtistName(), diary.getImage().getImageUrl()))
+                .collect(Collectors.toList());
+    }
+
+    public List<DiaryListResponse> getDiaryList(Long userId) {
+        User user = validateUserService.validateUserById(userId);
+        List<Diary> diaryList = diaryRepository.findAllByUser(user);
+        return diaryList.stream()
+                .map(diary -> new DiaryListResponse(diary.getDiaryId(), diary.getDiaryDate().toString(),diary.getImage().getImageUrl()))
                 .collect(Collectors.toList());
     }
 }

--- a/server/Spring/src/test/java/com/hanium/diarist/domain/diary/service/DiaryServiceTest.java
+++ b/server/Spring/src/test/java/com/hanium/diarist/domain/diary/service/DiaryServiceTest.java
@@ -8,6 +8,7 @@ import com.hanium.diarist.domain.diary.domain.Image;
 import com.hanium.diarist.domain.diary.dto.AlbumResponse;
 import com.hanium.diarist.domain.diary.dto.BookmarkDiaryResponse;
 import com.hanium.diarist.domain.diary.dto.DiaryDetailResponse;
+import com.hanium.diarist.domain.diary.dto.DiaryListResponse;
 import com.hanium.diarist.domain.diary.exception.DiaryNotFoundException;
 import com.hanium.diarist.domain.diary.repository.DiaryRepository;
 import com.hanium.diarist.domain.diary.repository.ImageRepository;
@@ -234,6 +235,41 @@ class DiaryServiceTest {
         }
 
         verify(diaryRepository, times(1)).findByUserIdAndFavorite(user.getUserId(),true);
+    }
+
+    @Test
+    void getDiaryListTest() {
+        // Given
+        User user = User.create("a@gmail.com", "test", SocialCode.KAKAO);
+
+        Artist artist = Artist.create("test1", "test", Period.Contemporary, "test", "test.png", "example.png");
+
+        Emotion emotion = Emotion.create("test", "testPrompt", "test.png");
+
+        Diary diary1 = new Diary(user, emotion, artist, LocalDate.now(), "test1", true, null);
+        Diary diary2 = new Diary(user, emotion, artist, LocalDate.now(), "test2", true, null);
+        Diary diary3 = new Diary(user, emotion, artist, LocalDate.now(), "test3", true, null);
+        List<Diary> diaries = Arrays.asList(diary1, diary2, diary3);
+
+        Image image1 = new Image(diary1, "test1.png");
+        Image image2 = new Image(diary2, "test2.png");
+        Image image3 = new Image(diary3, "test3.png");
+
+        diary1.setImage(image1);
+        diary2.setImage(image2);
+        diary3.setImage(image3);
+
+        when(validateUserService.validateUserById(user.getUserId())).thenReturn(user);
+        when(diaryRepository.findAllByUser(user)).thenReturn(diaries);
+
+        // When
+        List<DiaryListResponse> diaryList = diaryService.getDiaryList(user.getUserId());
+
+        // Then
+        assertNotNull(diaryList);
+        assertEquals(3, diaryList.size());
+
+        verify(diaryRepository, times(1)).findAllByUser(user);
     }
 
 


### PR DESCRIPTION
## Jira 티켓

* 유저스토리
[PROJ-20](https://hanium.atlassian.net/browse/PROJ-20)

* 하위태스크
[PROJ-81](https://hanium.atlassian.net/browse/PROJ-81)
[PROJ-92](https://hanium.atlassian.net/browse/PROJ-92)

## 제목

캘린더 페이지에 사용될 api 개발

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 캘린더 페이지에 사용될 api 미개발

## 변경 후

- 캘린더 페이지 api 
<img width="1031" alt="image" src="https://github.com/user-attachments/assets/36475e07-a3eb-41e8-8da5-d63420981278">

- 월을 바꾸면 통신량이 많아진다는 필요에 따라 jwt를 보낼시 해당 유저의 작성된 일기를 모두 보낸다. 
- 일기 데이터를 불러올 때 필요한 데이터 ( 일기, 이미지 ) 데이터를 DB에서 같이 불러온다.

```
@Query("select d from Diary d join fetch d.image where d.user = :user")
    List<Diary> findAllByUser(User user);

```


[PROJ-20]: https://hanium.atlassian.net/browse/PROJ-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROJ-81]: https://hanium.atlassian.net/browse/PROJ-81?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROJ-92]: https://hanium.atlassian.net/browse/PROJ-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ