### PR TITLE
refactor : PROJ-19 : google 로그인 로직 수정

### DIFF
--- a/server/Spring/src/main/java/com/hanium/diarist/common/config/SecurityConfig.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/common/config/SecurityConfig.java
@@ -80,6 +80,7 @@ public class SecurityConfig {
                 "/v3/api-docs/**",
                 "/oauth2/refresh",
                 "/oauth2/google/login",
+                "/oauth2/google/login/code",
                 "/oauth2/kakao/login"
         };
     }


### PR DESCRIPTION
## Jira 티켓

* 유저스토리
[PROJ-19](https://hanium.atlassian.net/browse/PROJ-19)
* 하위태스크
[PROJ-161](https://hanium.atlassian.net/browse/PROJ-161)

## 제목

google 로그인 로직 수정

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 승인코드로 구글 access token을 받고, access token으로 유저 프로필을 받은다음 jwt를 생성했음

## 변경 후

- 클라이언트에서 구글 access token과 refresh token을 받고 해당 토큰을 서버로 전달.
- 서버에서 access token을 가지고 유저 프로필을 받고 jwt를 생성하도록 변경.
- 필요 파라미터 다음과 같이 전달
![image](https://github.com/user-attachments/assets/c785df9d-d0f0-43ef-aca9-75342bc3d967)

- 승인코드로 access token을 가져오는 부분이 사라짐


[PROJ-19]: https://hanium.atlassian.net/browse/PROJ-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROJ-161]: https://hanium.atlassian.net/browse/PROJ-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ