### PR TITLE
feat : PROJ-30 : AI 서버에서 카프카로 일기 작성완료 메세지를 보낼 때 메세지에 user_id 데이터 추가

### DIFF
--- a/model/diary/consumer/create_diary_consumer.py
+++ b/model/diary/consumer/create_diary_consumer.py
@@ -50,9 +50,9 @@ def generate_image(description):
     return response.data[0].url
 
 
-def send_response(diary_id):
+def send_response(user_id, diary_id):
     producer = Producer({'bootstrap.servers': KAFKA_BROKER_URL})
-    response_message = json.dumps({"diary_id": diary_id})
+    response_message = json.dumps({"diary_id": diary_id, "user_id": user_id})
     producer.produce(RESPONSE_DIARY_TOPIC, key=str(diary_id), value=response_message)
     producer.flush()
 
@@ -95,7 +95,7 @@ def process_message(message):
         )
         new_diary.save()
 
-        send_response(new_diary.diary_id)
+        send_response(user_id, new_diary.diary_id)
     
     except Diary.DoesNotExist:
         return f"Diary for user {user_id} on {diary_date} does not exist."

--- a/model/diary/consumer/re_create_diary_consumer.py
+++ b/model/diary/consumer/re_create_diary_consumer.py
@@ -50,9 +50,9 @@ def generate_image(description):
     return response.data[0].url
 
 
-def send_response(diary_id):
+def send_response(user_id, diary_id):
     producer = Producer({'bootstrap.servers': KAFKA_BROKER_URL})
-    response_message = json.dumps({"diary_id": diary_id})
+    response_message = json.dumps({"diary_id": diary_id, "user_id": user_id})
     producer.produce(RESPONSE_DIARY_TOPIC, key=str(diary_id), value=response_message)
     producer.flush()
 
@@ -99,7 +99,7 @@ def process_message(message):
         diary.image = new_image
         diary.save()
 
-        send_response(diary.diary_id)
+        send_response(user_id, diary.diary_id)
 
     except Diary.DoesNotExist:
         return f"Diary for user {user_id} on {diary_date} does not exist."


### PR DESCRIPTION
## Jira 티켓
유저스토리
[PROJ-30](https://hanium.atlassian.net/browse/PROJ-30)

하위태스크
[PROJ-117](https://hanium.atlassian.net/browse/PROJ-117)

## 제목

AI 서버에서 카프카로 일기 작성완료 메세지를 보낼 때 메세지에 user_id 데이터 추가

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- AI 서버에서 그림을 생성하고 정상적으로 일기 데이터를 RDS, S3에 저장한 뒤 creat-diary-response 토픽으로 메세지를 보낼 때 생성 된 diary_id 값만 보내줬음.

## 변경 후

- AI 서버에서 그림을 생성하고 정상적으로 일기 데이터를 RDS, S3에 저장한 뒤 creat-diary-response 토픽으로 메세지를 보낼 때 diary_id값과 user_id 값을 보내줌으로써 어떤 유저가 작성 한 일기인지 API 서버에서 확인 할 수 있도록 설정하였음.

[PROJ-30]: https://hanium.atlassian.net/browse/PROJ-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROJ-117]: https://hanium.atlassian.net/browse/PROJ-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ