### PR TITLE
refactor : PROJ-166 : 화가 리스트 , 화가 선택 페이지 API 수정

### DIFF
--- a/server/Spring/src/main/java/com/hanium/diarist/domain/artist/controller/ArtistController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/artist/controller/ArtistController.java
@@ -4,6 +4,8 @@ import com.hanium.diarist.common.response.SuccessResponse;
 import com.hanium.diarist.domain.artist.domain.Period;
 import com.hanium.diarist.domain.artist.dto.*;
 import com.hanium.diarist.domain.artist.service.ArtistService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
@@ -18,7 +20,10 @@ import java.util.List;
 public class ArtistController {
     private final ArtistService artistService;
 
+
     @PostMapping("/create")
+    @Operation(summary = "화가 추가 api", description = "화가 추가 API.")
+    @ApiResponse(responseCode = "200", description = "화가 추가 완료")
     public ResponseEntity<SuccessResponse<List<CreateArtistResponse>>> createArtists(@RequestBody List<CreateArtistRequest> createArtistRequests) {
         List<CreateArtistResponse> artists = artistService.createArtists(createArtistRequests);
         return SuccessResponse.of(artists).asHttp(HttpStatus.CREATED);
@@ -26,17 +31,29 @@ public class ArtistController {
     }
 
     @GetMapping("/list")
+    @Operation(summary = "화가 리스트 api", description = "화가 리스트, 모달에서 사용될 API.시대별로 필터링된 화가 리스트 제공")
+    @ApiResponse(responseCode = "200", description = "화가 리스트 제공 완료")
     public ResponseEntity<SuccessResponse<List<ArtistFilterByPeriodResponse>>> getArtistsFilterByPeriod(@RequestParam Period period) {
         List<ArtistFilterByPeriodResponse> artists = artistService.filterByPeriod(period);
         return SuccessResponse.of(artists).asHttp(HttpStatus.OK);
     }
 
+    @GetMapping("/select")
+    @Operation(summary = "화가 선택 페이지 api", description = "화가 선택, 모달에서 사용될 API. 시대별로 필터링된 화가 선택 리스트 제공")
+    @ApiResponse(responseCode = "200", description = "화가 선택페이지 데이터 제공 완료")
+    public ResponseEntity<SuccessResponse<List<SelectArtistResponse>>> getArtistsForSelect(@RequestParam Period period) {
+        List<SelectArtistResponse> artists = artistService.selectPeriod(period);
+        return SuccessResponse.of(artists).asHttp(HttpStatus.OK);
+    }
+
+    @Deprecated
     @GetMapping("/list/{artistId}")
     public ResponseEntity<SuccessResponse<ArtistResponse>> getArtist(@PathVariable Long artistId) {
         ArtistResponse artist = artistService.getArtist(artistId);
         return SuccessResponse.of(artist).asHttp(HttpStatus.OK);
     }
 
+    @Deprecated
     @GetMapping("/select/{artistId}")
     public ResponseEntity<SuccessResponse<SelectArtistResponse>> selectArtist(@PathVariable Long artistId) {
         SelectArtistResponse artist = artistService.selectArtist(artistId);

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/artist/dto/ArtistFilterByPeriodResponse.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/artist/dto/ArtistFilterByPeriodResponse.java
@@ -7,13 +7,14 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class ArtistFilterByPeriodResponse {
+    private final Long artistId;
     private final String artistName;
     private final String artistPicture;
     private final String description;
 
 
     public static ArtistFilterByPeriodResponse of(Artist artist) {
-        return new ArtistFilterByPeriodResponse(artist.getArtistName(), artist.getArtistPicture(), artist.getDescription());
+        return new ArtistFilterByPeriodResponse(artist.getArtistId(),artist.getArtistName(), artist.getArtistPicture(), artist.getDescription());
     }
 
 }

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/artist/dto/SelectArtistResponse.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/artist/dto/SelectArtistResponse.java
@@ -7,10 +7,12 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class SelectArtistResponse {
+    private final Long artistId;
     private final String artistName;
+    private final String artistPicture;
     private final String examplePicture;
 
     public static SelectArtistResponse of(Artist artist) {
-        return new SelectArtistResponse(artist.getArtistName(), artist.getExamplePicture());
+        return new SelectArtistResponse(artist.getArtistId(),artist.getArtistName(), artist.getArtistPicture(), artist.getExamplePicture());
     }
 }

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/artist/service/ArtistService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/artist/service/ArtistService.java
@@ -41,6 +41,17 @@ public class ArtistService {
     }
 
     @Transactional
+    public List<SelectArtistResponse> selectPeriod(Period period){
+        List<Artist> artists = artistRepository.findAllByPeriod(period);
+        List<SelectArtistResponse> artistFilterByPeriodResponses = new ArrayList<>();
+        for (Artist artist : artists) {
+            artistFilterByPeriodResponses.add(SelectArtistResponse.of(artist));
+        }
+        return artistFilterByPeriodResponses;
+    }
+
+
+    @Transactional
     public SelectArtistResponse selectArtist(Long artistId) {
         Artist artist = artistRepository.findByArtistId(artistId).orElseThrow(ArtistNotFoundException::new);
         return SelectArtistResponse.of(artist);


### PR DESCRIPTION
## Jira 티켓

* 유저스토리
[PROJ-25](https://hanium.atlassian.net/browse/PROJ-25)

* 하위 태스크
[PROJ-166](https://hanium.atlassian.net/browse/PROJ-166)

## 제목

화가 리스트 , 화가 선택 페이지 API 수정

## 작업유형

- [ ] 버그픽스
- [ ] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 화가 리스트 페이지 접속 이후 모달창을 띄울때 통신을 1회 더 하도록 코드가 구성

## 변경 후

- 화가 리스트, 선택 페이지 통신시 모달에서 띄울 데이터까지 한번에 제공
- 화가 선택 페이지 
<img width="707" alt="image" src="https://github.com/user-attachments/assets/e4632a0b-c8a2-4bc7-b9e1-f787c0fa54c0">

- 화가 리스트 페이지
<img width="1131" alt="image" src="https://github.com/user-attachments/assets/67926441-c921-48f9-b011-1ef4b3732751">




[PROJ-25]: https://hanium.atlassian.net/browse/PROJ-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROJ-166]: https://hanium.atlassian.net/browse/PROJ-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ