### PR TITLE
refactor : PROJ-111 : 일기 재성시 기존 이미지 레코드에 이미지 업데이트

### DIFF
--- a/model/diary/consumer/re_create_diary_consumer.py
+++ b/model/diary/consumer/re_create_diary_consumer.py
@@ -16,6 +16,7 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings')
 django.setup()
 
 from django.conf import settings
+from django.utils import timezone
 from diary.models import Diary, User, Emotion, Image, Artist
 from diary.utils import S3ImgUploader
 
@@ -145,17 +146,17 @@ def process_message(message):
         diary = Diary.objects.get(user=user, diary_date=diary_date)
 
         old_image_url = diary.image.image_url
-        old_image = diary.image
+        diary_image = diary.image
 
         S3ImgUploader.delete_image(old_image_url)
-        old_image.delete()
 
-        new_image = Image.objects.create(image_url=s3_url)
+        diary_image.image_url = s3_url
+        diary_image.created_at = timezone.now()
+        diary_image.save()
 
         diary.content = content
         diary.emotion = emotion
         diary.artist = artist
-        diary.image = new_image
         diary.save()
 
         send_response(user_id, diary.diary_id)


### PR DESCRIPTION
## Jira 티켓
유저스토리
[PROJ-30](https://hanium.atlassian.net/browse/PROJ-30)

하위태스크
[PROJ-111](https://hanium.atlassian.net/browse/PROJ-111)
## 제목

일기 재성시 기존 이미지 레코드에 이미지 업데이트

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [x] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 일기 재생성 요청 시 기존 일기에 대한 이미지 레코드를 삭제하고 재생성 된 이미지 url을 새로운 이미지 레코드에 저장 한 뒤 재생성 요청 시 받은 일기 데이터와 함께 일기 레코드를 업데이트 함. 

## 변경 후

- 일기 재생성 요청 시 기존 이미지 레코드에 새롭게 생성 된 이미지 url을 넣어서 업데이트 하고 별도의 이미지 레코드를 추가로 생성하거나 삭제하지 않음.
- 일기 재생성 요청 시 불필요한 추가 이미지 생성 및 삭제 작업을 없앰.


[PROJ-111]: https://hanium.atlassian.net/browse/PROJ-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PROJ-30]: https://hanium.atlassian.net/browse/PROJ-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ