### PR TITLE
feat : PROJ-42 : 유저의 오늘 일기 작성 여부 확인 api

### DIFF
--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/controller/DiaryController.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/controller/DiaryController.java
@@ -118,5 +118,13 @@ public class DiaryController {
         return SuccessResponse.of(response).asHttp(HttpStatus.OK);
     }
 
+    @GetMapping("/today")
+    @Operation(summary = "오늘 일기 작성 여부 조회", description = "오늘 일기 작성 여부 조회 API")
+    @ApiResponse(responseCode = "200", description = "오늘 일기 작성 여부 조회 성공")
+    public ResponseEntity<SuccessResponse<TodayDiaryResponse>> getTodayDiary(@AuthUser JwtTokenInfo jwtTokenInfo) {
+        TodayDiaryResponse response = diaryService.getTodayDiary(jwtTokenInfo.getUserId());
+        return SuccessResponse.of(response).asHttp(HttpStatus.OK);
+    }
+
 
 }

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/CreateDiaryResponse.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/CreateDiaryResponse.java
@@ -1,14 +1,7 @@
 package com.hanium.diarist.domain.diary.dto;
 
-import com.hanium.diarist.domain.artist.domain.Artist;
-import com.hanium.diarist.domain.diary.domain.Image;
-import com.hanium.diarist.domain.emotion.domain.Emotion;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
 import lombok.*;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 @Getter
 @Setter

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/TodayDiaryResponse.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/dto/TodayDiaryResponse.java
@@ -1,0 +1,10 @@
+package com.hanium.diarist.domain.diary.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TodayDiaryResponse {
+    public boolean diaryExist;
+}

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/repository/DiaryRepository.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/repository/DiaryRepository.java
@@ -22,4 +22,6 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     @Query("select d from Diary d join fetch d.emotion join fetch d.artist join fetch d.image where d.user.userId = :userId and d.favorite = :bool")
     List<Diary> findByUserIdAndFavorite(Long userId, boolean bool);
+
+    boolean existsByUserAndDiaryDate(User user, LocalDate now);
 }

--- a/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/DiaryService.java
+++ b/server/Spring/src/main/java/com/hanium/diarist/domain/diary/service/DiaryService.java
@@ -2,10 +2,7 @@ package com.hanium.diarist.domain.diary.service;
 
 import com.hanium.diarist.domain.diary.domain.Diary;
 import com.hanium.diarist.domain.diary.domain.Image;
-import com.hanium.diarist.domain.diary.dto.AlbumResponse;
-import com.hanium.diarist.domain.diary.dto.BookmarkDiaryResponse;
-import com.hanium.diarist.domain.diary.dto.DiaryDetailResponse;
-import com.hanium.diarist.domain.diary.dto.DiaryListResponse;
+import com.hanium.diarist.domain.diary.dto.*;
 import com.hanium.diarist.domain.diary.exception.DiaryNotFoundException;
 import com.hanium.diarist.domain.diary.repository.DiaryRepository;
 import com.hanium.diarist.domain.diary.repository.ImageRepository;
@@ -18,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -108,6 +106,12 @@ public class DiaryService {
         return diaryList.stream()
                 .map(diary -> new DiaryListResponse(diary.getDiaryId(), diary.getDiaryDate().toString(),diary.getImage().getImageUrl()))
                 .collect(Collectors.toList());
+    }
+
+    public TodayDiaryResponse getTodayDiary(Long userId) {
+        User user = validateUserService.validateUserById(userId);
+        boolean diaryExist = diaryRepository.existsByUserAndDiaryDate(user, LocalDate.now());
+        return new TodayDiaryResponse(diaryExist);
     }
 }
 


### PR DESCRIPTION
## Jira 티켓
* 유저스토리
[PROJ-42](https://hanium.atlassian.net/browse/PROJ-42)
* 하위태스크
[PROJ-105](https://hanium.atlassian.net/browse/PROJ-105)

## 제목

유저의 오늘 일기 작성 여부 확인 api

## 작업유형

- [ ] 버그픽스
- [x] 기능 추가/수정
- [ ] 코드 스타일 갱신
- [ ] 마크업 완성
- [ ] 스타일링 완성
- [ ] 리팩터링(Refactoring)
- [ ] 문서 추가/수정
- [ ] 기타:

## 변경 전

- 유저가 오늘 일기를 작성했는지 확인할 수 있는 로직 미구현
- 이로 인한 모든 유저에게 알림을 보내야 하는 문제 발생

## 변경 후

- 해당 유저의 오늘의 일기 작성 여부를 확인할 수 있는 api 생성
- 토큰을 가지고 GET `diary/today` 요청시 true/false 값 반환

![image](https://github.com/user-attachments/assets/c8126229-b084-489e-a8cc-455fcc406c6e)
![image](https://github.com/user-attachments/assets/e221e4c8-b8d4-49dd-9f68-cac500bcd2bf)



[PROJ-42]: https://hanium.atlassian.net/browse/PROJ-42?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PROJ-105]: https://hanium.atlassian.net/browse/PROJ-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ